### PR TITLE
seo: weekly optimizations Apr 15 — titles, schemas, llms.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,33 @@
+# WePlanify
+
+> WePlanify is a free, all-in-one group trip planning app. It combines collaborative itineraries, group polls, shared budget tracking, and packing list coordination in a single bilingual (English/French) tool. Built specifically for groups of friends, families, and teams — not solo travellers.
+
+## Key pages
+
+- [Homepage (EN)](https://www.weplanify.com/en): Start planning a group trip for free
+- [Homepage (FR)](https://www.weplanify.com/fr): Planifier un voyage de groupe gratuitement
+- [Best group trip planner apps — Comparison 2026](https://www.weplanify.com/en/alternatives/best-group-trip-planner-apps): Honest comparison of WePlanify, Wanderlog, Splitwise, TripIt, SquadTrip and more
+- [WePlanify vs Wanderlog](https://www.weplanify.com/en/alternatives/wanderlog): Feature-by-feature comparison
+- [Plan a trip with friends](https://www.weplanify.com/en/trip-with-friends): Use case page for friend groups
+- [Bachelorette trip planner](https://www.weplanify.com/en/bachelorette-trip): Tools for bachelorette and hen party planning
+- [Road trip planner](https://www.weplanify.com/en/road-trip): Group road trip route planning, gas budgets, packing coordination
+- [Family trip planner](https://www.weplanify.com/en/family-trip): Planning family holidays collaboratively
+- [Team building & corporate retreats](https://www.weplanify.com/en/team-building): Plan offsites and company retreats
+- [Group trip planning guide](https://www.weplanify.com/en/guides/plan-group-trip): Step-by-step guide to organising any group trip
+- [Blog — Best collaborative travel apps (FR)](https://www.weplanify.com/fr/blog/meilleures-applications-voyage-groupe): Comparatif des meilleures applications de voyage collaboratif
+- [FAQ](https://www.weplanify.com/en/faq): Frequently asked questions about WePlanify
+
+## Features
+
+- **Collaborative itinerary**: Build a shared day-by-day plan everyone can edit in real time
+- **Group polls**: Vote on destinations, dates, and activities — anonymous voting available
+- **Shared budget tracker**: Log expenses, split costs, settle up at the end
+- **Packing lists**: Assign shared items so nothing gets duplicated or forgotten
+- **AI-powered discovery**: Get activity suggestions based on destination and group interests
+- **Bilingual**: Fully available in English and French
+
+## About
+
+WePlanify is free to use. No app download required — works in any browser. Designed for groups of 2 to 50+ people. Available at app.weplanify.com.
+
+Contact: contact@weplanify.com

--- a/src/app/[locale]/alternatives/wanderlog/page.tsx
+++ b/src/app/[locale]/alternatives/wanderlog/page.tsx
@@ -440,6 +440,19 @@ export default async function WanderlogComparisonPage({ params }: Props) {
     })),
   };
 
+  const articleLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: locale === "fr"
+      ? "WePlanify vs Wanderlog — Quel Planificateur de Voyage de Groupe Choisir ? (2026)"
+      : "WePlanify vs Wanderlog — Which Group Trip Planner Is Better? (2026)",
+    author: { "@type": "Person", name: "Alex Martin", jobTitle: "Travel Editor" },
+    publisher: { "@type": "Organization", name: "WePlanify", url: "https://www.weplanify.com" },
+    datePublished: "2026-03-19",
+    dateModified: "2026-04-15",
+    mainEntityOfPage: { "@type": "WebPage", "@id": `https://www.weplanify.com/${locale}/alternatives/wanderlog` },
+  };
+
   return (
     <>
       <script
@@ -449,6 +462,10 @@ export default async function WanderlogComparisonPage({ params }: Props) {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
       />
       <Nav navData={navData} navigationData={navigationData} />
 

--- a/src/app/[locale]/blog/meilleures-applications-voyage-groupe/page.tsx
+++ b/src/app/[locale]/blog/meilleures-applications-voyage-groupe/page.tsx
@@ -35,9 +35,9 @@ const meta = {
   },
   fr: {
     title:
-      "Les Meilleures Applis pour Organiser un Voyage entre Amis (2026)",
+      "Application Voyage Collaboratif — Meilleures Applis Voyage de Groupe (2026)",
     description:
-      "On a testé les applis de voyage de groupe les plus populaires. Découvrez laquelle choisir selon vos besoins : itinéraire, budget, sondages, bagages.",
+      "Comparatif des meilleures applications de voyage collaboratif : WePlanify, Wanderlog, Splitwise et plus. Testées en conditions réelles pour votre groupe.",
   },
 };
 

--- a/src/app/[locale]/road-trip/page.tsx
+++ b/src/app/[locale]/road-trip/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const metadata = await generateMetadataFromSanity(locale, PATHNAME);
   const isEn = locale === "en";
   const title = isEn
-    ? "Plan a Road Trip With Your Crew — Route Planner for Groups | WePlanify"
+    ? "How to Plan a Road Trip With Friends — Group Route Planner | WePlanify"
     : "Organiser un Road Trip entre Amis — Planificateur d'Itinéraire de Groupe | WePlanify";
   const description = isEn
     ? "Plan your group road trip with WePlanify. Collaborative route planning, shared gas budgets, packing coordination, and group polls for every stop along the way."
@@ -66,7 +66,7 @@ export default async function RoadTripPage({ params }: Props) {
     headline: isEn ? "Plan a Road Trip With Your Crew" : "Organiser un Road Trip entre Amis",
     author: { "@type": "Person", name: "Alex Martin", jobTitle: "Travel Editor" },
     publisher: { "@type": "Organization", name: "WePlanify", url: SITE_URL },
-    datePublished: "2026-03-19", dateModified: "2026-03-31",
+    datePublished: "2026-03-19", dateModified: "2026-04-15",
     mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}/${locale}${PATHNAME}` },
   };
 

--- a/src/app/[locale]/team-building/page.tsx
+++ b/src/app/[locale]/team-building/page.tsx
@@ -66,7 +66,7 @@ export default async function TeamBuildingPage({ params }: Props) {
     headline: isEn ? "Plan a Team Building Trip That People Actually Want to Go On" : "Organisez un Séminaire d'Entreprise où les Gens Veulent Vraiment Aller",
     author: { "@type": "Person", name: "Alex Martin", jobTitle: "Travel Editor" },
     publisher: { "@type": "Organization", name: "WePlanify", url: SITE_URL },
-    datePublished: "2026-03-19", dateModified: "2026-03-31",
+    datePublished: "2026-03-19", dateModified: "2026-04-15",
     mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}/${locale}${PATHNAME}` },
   };
 
@@ -93,12 +93,35 @@ export default async function TeamBuildingPage({ params }: Props) {
     mainEntity: faqItems.map((item) => ({ "@type": "Question", name: item.q, acceptedAnswer: { "@type": "Answer", text: item.a } })),
   };
 
+  const howToLd = {
+    "@context": "https://schema.org", "@type": "HowTo",
+    name: isEn ? "How to Plan a Corporate Team Retreat" : "Comment organiser un séminaire d'entreprise",
+    description: isEn
+      ? "Step-by-step guide to planning a team building retreat that your whole team will enjoy."
+      : "Guide étape par étape pour organiser un séminaire d'entreprise que toute votre équipe appréciera.",
+    totalTime: "PT90D",
+    step: isEn
+      ? [
+          { "@type": "HowToStep", name: "Define goals and destination", text: "Set retreat objectives, fix a rough budget, and shortlist 2–3 destination ideas. Run a poll to involve the team in the destination choice.", position: 1 },
+          { "@type": "HowToStep", name: "Book accommodation and activities", text: "Confirm the venue, reserve group activities, and finalize travel logistics. Build a shared itinerary everyone can see.", position: 2 },
+          { "@type": "HowToStep", name: "Share the final plan", text: "Distribute the finalized itinerary, collect dietary needs and accessibility requirements, and confirm headcounts.", position: 3 },
+          { "@type": "HowToStep", name: "Stay flexible on the day", text: "Keep the shared itinerary updated in real time so everyone stays informed when plans change.", position: 4 },
+        ]
+      : [
+          { "@type": "HowToStep", name: "Définir les objectifs et la destination", text: "Fixez les objectifs du séminaire, établissez un budget indicatif et présélectionnez 2–3 idées de destinations. Lancez un sondage pour impliquer l'équipe.", position: 1 },
+          { "@type": "HowToStep", name: "Réserver l'hébergement et les activités", text: "Confirmez le lieu, réservez les activités de groupe et finalisez la logistique transport. Construisez un itinéraire partagé visible par tous.", position: 2 },
+          { "@type": "HowToStep", name: "Partager le programme final", text: "Diffusez l'itinéraire finalisé, recueillez les régimes alimentaires et confirmez les effectifs.", position: 3 },
+          { "@type": "HowToStep", name: "Rester flexible le jour J", text: "Maintenez l'itinéraire partagé à jour en temps réel pour que tout le monde reste informé en cas de changement.", position: 4 },
+        ],
+  };
+
   return (
     <>
       <AuthorJsonLd />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }} />
       <Nav navData={navData} navigationData={navigationData} />
 
       <main className="min-h-screen bg-[#FFFBF5]">


### PR DESCRIPTION
- Blog FR: retitle to "Application Voyage Collaboratif" to capture pos 7.1 quick win
- Road-trip EN: title now starts with "How to Plan a Road Trip" to target pos 9.5 keyword
- Team-building: add HowTo JSON-LD schema (4 steps) for rich snippets + update dateModified
- Wanderlog: add Article JSON-LD with dateModified to signal freshness (post -65% impressions drop)
- Add public/llms.txt for LLM indexing (ChatGPT, Perplexity, Claude)