### PR TITLE
content: add 2 new SEO blog articles — EVJF guide + group trip budget

### DIFF
--- a/src/app/[locale]/blog/group-trip-budget/page.tsx
+++ b/src/app/[locale]/blog/group-trip-budget/page.tsx
@@ -1,0 +1,962 @@
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import Link from "next/link";
+import { sanityFetch } from "@/sanity/lib/fetch";
+import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
+import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
+import { setRequestLocale } from "next-intl/server";
+import { routing } from "@/i18n/routing";
+import { Metadata } from "next";
+import Breadcrumb from "@/components/Breadcrumb";
+import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
+
+// ---------------------------------------------------------------------------
+// Static params
+// ---------------------------------------------------------------------------
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+const SITE_URL = "https://www.weplanify.com";
+const PATHNAME_EN = "/blog/group-trip-budget";
+const PATHNAME_FR = "/blog/budget-voyage-groupe";
+
+const meta = {
+  en: {
+    title: "Group Trip Budget: How to Split Costs Without the Drama",
+    description:
+      "The complete guide to managing money on a group trip — setting a budget everyone agrees on, splitting costs fairly, and settling up cleanly at the end.",
+  },
+  fr: {
+    title: "Budget Voyage de Groupe : Comment Partager les Frais Sans Galère",
+    description:
+      "Le guide complet pour gérer l'argent en voyage de groupe — fixer un budget, répartir les frais équitablement et solder les comptes proprement.",
+  },
+};
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const l = locale === "fr" ? meta.fr : meta.en;
+  const pathname = locale === "fr" ? PATHNAME_FR : PATHNAME_EN;
+  const currentUrl = `${SITE_URL}/${locale}${pathname}`;
+
+  return {
+    title: l.title,
+    description: l.description,
+    authors: [{ name: "WePlanify" }],
+    openGraph: {
+      type: "article",
+      locale: locale === "fr" ? "fr_FR" : "en_US",
+      url: currentUrl,
+      siteName: "WePlanify",
+      title: l.title,
+      description: l.description,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: l.title,
+      description: l.description,
+    },
+    alternates: {
+      canonical: currentUrl,
+      languages: {
+        en: `${SITE_URL}/en${PATHNAME_EN}`,
+        fr: `${SITE_URL}/fr${PATHNAME_FR}`,
+        "x-default": `${SITE_URL}/en${PATHNAME_EN}`,
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Content
+// ---------------------------------------------------------------------------
+
+type Section = {
+  id: string;
+  title: string;
+  paragraphs: string[];
+};
+
+type ContentLocale = {
+  readTime: string;
+  heroTag: string;
+  h1: string;
+  intro: string;
+  tocTitle: string;
+  toc: { id: string; label: string }[];
+  sections: {
+    moneyMess: Section;
+    setBudgetEarly: Section;
+    splitByCategory: Section & { categories: { title: string; items: string[] }[] };
+    onePayerSystem: Section;
+    trackRealTime: Section;
+    unequalBudgets: Section;
+    settlingUp: Section;
+  };
+  faq: {
+    title: string;
+    items: { q: string; a: string }[];
+  };
+  cta: {
+    title: string;
+    text: string;
+    button: string;
+  };
+  discoverMore: string;
+  readMore: string;
+};
+
+const content: { en: ContentLocale; fr: ContentLocale } = {
+  en: {
+    readTime: "9 min read",
+    heroTag: "Money & Travel 2026",
+    h1: "Group Trip Budget: How to Split Costs Without the Drama",
+    intro:
+      "Ask anyone who has ever traveled with a group of four or more people what the hardest part was, and money will come up within the first three answers. Not the flights, not the accommodation — money. Who paid for dinner, who still owes fifty dollars, why one person keeps ordering expensive cocktails while everyone else is splitting the tab. Group trip budgeting does not have to be a source of conflict. With the right system in place before you leave, it becomes almost invisible. This guide covers everything: setting a realistic budget, splitting costs in a way that feels fair, tracking expenses in real time, and settling up cleanly when the trip is over.",
+
+    tocTitle: "Table of Contents",
+    toc: [
+      { id: "money-mess", label: "Why Group Trip Money Always Gets Messy" },
+      { id: "set-budget-early", label: "Set the Budget Before You Book Anything" },
+      { id: "split-by-category", label: "Split by Category, Not by Everything" },
+      { id: "one-payer-system", label: "The One-Payer System" },
+      { id: "track-real-time", label: "Track in Real Time, Not at the End" },
+      { id: "unequal-budgets", label: "Handling Unequal Budgets in the Group" },
+      { id: "settling-up", label: "Settling Up: The Clean Way" },
+      { id: "faq", label: "FAQ" },
+    ],
+
+    sections: {
+      moneyMess: {
+        id: "money-mess",
+        title: "Why Group Trip Money Always Gets Messy",
+        paragraphs: [
+          "It starts innocently. Someone books the Airbnb because they have the card with the highest limit. Someone else buys the group train tickets to save time. A third person covers dinner because the restaurant only accepted a single payment. Before the trip is even over, one person has fronted $800 and has no idea how to ask for it back without sounding petty.",
+          "The root problem is that group trips involve people with different incomes, different spending habits, and wildly different ideas of what 'reasonable' means. For one friend, $30 for a museum entry is nothing. For another, it is a significant chunk of their daily budget. Nobody talks about this before leaving, so every spending decision becomes a silent negotiation where someone always ends up feeling either guilty or resentful.",
+          "Then there is the tracking problem. Nobody wants to be the person furiously typing expenses into a spreadsheet while everyone else is enjoying the sunset. So nothing gets recorded. By the last day, half the transactions are forgotten and the other half are disputed. Settling up turns into an hour-long archaeology project — and the exact moment when perfectly pleasant trips go sideways.",
+          "The solution is not a complicated accounting system. It is a simple shared agreement, made before departure, on three things: how much to spend per person, which costs to split and which to pay individually, and how to log everything as it happens. Get those three things right and money stops being a source of tension.",
+        ],
+      },
+
+      setBudgetEarly: {
+        id: "set-budget-early",
+        title: "Set the Budget Before You Book Anything",
+        paragraphs: [
+          "The money conversation needs to happen before you book a single thing — before the Airbnb, before the flights, before anyone buys train tickets or starts comparing restaurant menus. Once money has been spent, the budget is no longer theoretical. Real numbers create real pressure, and people who would have spoken up in a planning conversation start staying quiet to avoid conflict.",
+          "The easiest way to open the conversation is with brackets. Instead of asking \"how much do you want to spend?\", which forces people to state a number and feel judged, present three options: a lean trip ($800–$1,000 per person all-in), a comfortable trip ($1,200–$1,600 per person), and a generous trip ($2,000+ per person). Ask everyone to privately pick which bracket works for them. If the group clusters around one bracket, you have your budget. If there is a wide spread, that is an important signal to address early — not on day three when someone orders a $45 main course.",
+          "Once you have a rough per-person total, break it down by category. A realistic breakdown for a 7-day trip might look like: accommodation (30–35% of the budget), transportation including flights and local (30–40%), food and drinks (20–25%), activities and experiences (10–15%), and a buffer for unexpected costs (5–10%). Having these categories in writing, even in a shared note, means everyone is calibrating against the same expectations.",
+          "Use WePlanify's group polls feature to vote on accommodation options and activities before committing. When the whole group decides together what to include in the budget, there is no one person to blame if something turns out to be expensive — and everyone feels ownership over the plan. Decisions made democratically are accepted more easily, including the financial ones.",
+        ],
+      },
+
+      splitByCategory: {
+        id: "split-by-category",
+        title: "Split by Category, Not by Everything",
+        paragraphs: [
+          "One of the most common mistakes groups make is trying to split absolutely every expense equally — or, conversely, having everyone pay for themselves all the time. Both extremes create friction. The first leads to resentment when consumption is unequal. The second makes every meal feel like a transaction and defeats the point of traveling together.",
+          "The smarter approach is to split by category. Some costs are genuinely shared and should be split equally. Others are personal and should be paid individually. Drawing this line clearly before the trip starts removes 90% of the awkward conversations.",
+          "The categories below are a proven starting framework. Adjust them to fit your group, but the key is to agree on them before you leave.",
+        ],
+        categories: [
+          {
+            title: "Split equally (shared costs)",
+            items: [
+              "Accommodation — Airbnb, hotel, hostel dorms. Everyone benefits equally regardless of the size of their room.",
+              "Group transport — rental car, train tickets booked together, airport transfers for the whole group.",
+              "Group activities — tours, museum entries, tickets for experiences the whole group attends.",
+              "Groceries for shared meals — if the group cooks together, split the shopping bill.",
+            ],
+          },
+          {
+            title: "Pay individually (personal costs)",
+            items: [
+              "Personal meals when the group eats at different restaurants or orders different things.",
+              "Personal drinks — especially alcohol, where consumption varies enormously.",
+              "Souvenirs, personal shopping, and anything that only benefits one person.",
+              "Personal transport — taxis to a separate activity, solo day trips.",
+            ],
+          },
+        ],
+      },
+
+      onePayerSystem: {
+        id: "one-payer-system",
+        title: "The One-Payer System",
+        paragraphs: [
+          "Splitting the bill at the moment of payment — everyone fumbling for cards while the waiter waits — is slow, awkward, and error-prone. A much cleaner approach is the one-payer system: one person pays for a shared expense, logs it immediately in a shared tracker, and the group settles up at the end of the trip.",
+          "The key word is 'immediately.' The system only works if the person who pays logs it on the spot, before anyone has moved on or forgotten the amount. This means having a shared budget tracker open and accessible at all times — not a mental note to add it to the spreadsheet later. WePlanify's shared budget tracker is built for exactly this: one tap to log a new expense, select who paid and who it was for, and everyone sees it instantly.",
+          "To keep things fair, rotate who pays over the course of the trip. One person covers dinner, another covers the next activity, a third covers the museum tickets. If the amounts are logged accurately, the imbalances will even out by the end — and if they do not, the final settlement will be a handful of transfers rather than a forensic accounting exercise.",
+          "A simple rule: if you pay for something shared and do not log it within five minutes, you have probably lost it. Build the habit early, on day one, so it becomes automatic.",
+        ],
+      },
+
+      trackRealTime: {
+        id: "track-real-time",
+        title: "Track in Real Time, Not at the End",
+        paragraphs: [
+          "Every group that has waited until the last night to 'figure out the money' has regretted it. Memories are unreliable, amounts get rounded, and one person always feels like they contributed more than the numbers show. The last evening of a trip is the worst possible time to have a financial reconciliation — everyone is tired, some people are already calculating their flights, and the emotional goodwill of the trip is at its most fragile.",
+          "Real-time tracking solves this completely. When every expense is logged as it happens, there is no reconciliation to do at the end. The numbers are already there. Everyone has been watching the running total throughout the trip, so nothing comes as a surprise. The final settlement is a formality, not a negotiation.",
+          "The practical requirement is a tracker that everyone can see and contribute to from their phone. A shared spreadsheet technically works but requires a level of discipline and mobile usability that most groups do not maintain. Dedicated tools like WePlanify's budget tracker are designed for this: add an expense in ten seconds, see who owes what in real time, get a settlement summary at any point. It removes the friction that causes people to stop tracking in the first place.",
+          "Set a daily or two-day check-in habit where someone looks at the running totals and flags any expenses that were missed. On a 7-day trip, a two-minute review every other day catches any gaps and keeps everyone aligned. It also builds a shared sense of where the trip stands financially — so nobody gets a shock at the end.",
+          "For road trips specifically, track fuel and tolls as a shared expense from the start. Gas costs can add up to $200–$400 for a week-long road trip and are easy to forget if the driver keeps paying and assuming they will get reimbursed later. Log every fill-up immediately. Check out our road trip planning guide for more specific tips on managing shared costs on the road.",
+        ],
+      },
+
+      unequalBudgets: {
+        id: "unequal-budgets",
+        title: "Handling Unequal Budgets in the Group",
+        paragraphs: [
+          "Almost every friend group has at least one person who is in a different financial situation than the others. Maybe they are between jobs, saving for something big, or simply earn less. This is normal, and it does not have to mean they get left out — but it does require a bit of intentional design in how you structure the trip.",
+          "The first rule is to make space for the conversation before the trip, not during it. If you know someone in the group has a tighter budget, reach out privately and ask what range feels comfortable for them. This is not charity — it is good group dynamics. A trip where one person is stressed about money the whole time is worse for everyone.",
+          "For accommodation, look for options where cost does not vary by individual. Renting a house or large Airbnb and splitting it equally is often cheaper per person than individual hotel rooms, and it means no one is paying more than anyone else for their sleeping situation. When everyone is in the same space, there is no visible tier system.",
+          "For meals and activities, design a mix. Plan some group meals at mid-range restaurants where the bill splits easily, and make individual payment the default for anything higher-end. If the group wants to do an expensive activity — a cooking class, a boat trip, a Michelin-starred dinner — make it optional and have an equally good alternative for those who pass. This structure means no one has to explain themselves or feel the spotlight.",
+          "One practical technique: at the start of the trip, agree on a daily shared expenses cap per person. Something like $50/day covers accommodation share, shared transport, and one group meal. Anything above that is individual choice and individual cost. This cap creates a predictable floor that everyone can commit to, while leaving room for those who want to spend more to do so freely.",
+        ],
+      },
+
+      settlingUp: {
+        id: "settling-up",
+        title: "Settling Up: The Clean Way",
+        paragraphs: [
+          "The ideal time to settle up is before you leave for the airport or the day after you get back — while the trip is still fresh, the numbers are still visible, and the goodwill is still intact. Waiting a week or more creates friction: people get busy, memories fade, and a $45 debt starts to feel either too small to bring up or too large to ignore.",
+          "The goal of settling up is to minimize the number of transfers. If six people each owe different amounts to different people, the naive approach would require up to fifteen separate transactions. A smart tracker calculates the minimum number of transfers needed to bring everyone to zero — usually two or three per person for a typical group trip.",
+          "Here is how to read the final settlement: the tracker shows a net balance for each person — positive means they are owed money, negative means they owe. The settlement algorithm then finds the most efficient path from every negative balance to every positive one. Person A owes $85 and Person B is owed $90, so A pays B $85. Done. Person C is owed $40, Person D owes $15, Person E owes $25: D pays C $15, E pays C $25. Three transactions instead of a tangled web.",
+          "The settlement works best when everyone confirms receipt of their transfer on the day it happens. A simple message in the group chat — 'sent $85, done' — closes the loop publicly and prevents anyone from wondering if they need to follow up. Within 48 hours of the trip ending, every balance should be zero.",
+          "One final note: do the settlement before the memories of who paid what start to drift. Financial clarity at the end of a trip is what makes you actually want to travel with these people again.",
+        ],
+      },
+    },
+
+    faq: {
+      title: "Frequently Asked Questions",
+      items: [
+        {
+          q: "How do you split trip costs fairly between friends?",
+          a: "The fairest approach is to split shared costs (accommodation, group transport, group activities) equally, and let everyone pay individually for personal expenses like individual meals and drinks. Agree on these categories before the trip starts, log every shared expense as it happens using a shared tracker, and settle up at the end based on who paid what. This avoids the two extremes of splitting everything equally (which penalizes light spenders) or everyone paying for themselves (which makes the trip feel transactional).",
+        },
+        {
+          q: "What's the best app to track group trip expenses?",
+          a: "For a dedicated group trip experience, WePlanify's built-in budget tracker is designed specifically for travel groups — it logs expenses in real time, tracks who paid and who participated, and calculates a settlement at the end. Splitwise is the best pure expense-splitting tool and handles multiple currencies well. The key is to use something everyone in the group will actually open on their phone. A tool that three out of six people use is worse than a simpler one that all six use consistently.",
+        },
+        {
+          q: "Should everyone pay the same amount on a group trip?",
+          a: "For shared costs like accommodation and group transport, yes — splitting equally is fairest because everyone benefits the same. For personal spending like individual meals, drinks, and activities, no — people should pay their own way. The practical solution is to track shared expenses in a pool and let personal spending be individual. If there are meaningful income differences in the group, set a daily cap for shared expenses that everyone can comfortably meet, and let higher-spending individuals cover their extras themselves.",
+        },
+        {
+          q: "How do you handle someone who doesn't pay their share?",
+          a: "Prevention is better than cure: use a shared tracker that everyone can see so balances are transparent throughout the trip, not just at the end. When someone can see in real time that they owe $200, they are more likely to address it before it becomes a bigger number. If someone genuinely cannot pay after the trip, address it privately and directly — not in the group chat. Set a specific deadline ('can you send this by Sunday?') rather than a vague 'whenever you can.' For future trips, some groups ask everyone to contribute to a shared trip fund before departure, so there is no settling up at the end.",
+        },
+        {
+          q: "What costs should you split equally vs. individually?",
+          a: "Split equally: accommodation, rental cars, group transport (trains, airport transfers), shared groceries for group meals, and any activity the whole group does together. Pay individually: personal restaurant meals, alcoholic drinks, souvenirs, personal transport (a solo taxi, an extra activity), and anything that only benefits one person. The general rule is: if it would be weird for one person to not participate in it, split it. If it is a personal choice, pay for it yourself.",
+        },
+        {
+          q: "When should you settle up on a group trip?",
+          a: "Ideally on the last day of the trip or within 24–48 hours of returning home, while everything is still fresh and the goodwill of the trip is intact. Use a shared tracker that calculates the minimum number of transfers needed — this keeps it fast and painless. Confirm each payment in the group chat so everyone knows when their balance is cleared. Waiting longer than a week makes the conversation harder and the numbers murkier. Set a firm deadline as a group before you leave.",
+        },
+      ],
+    },
+
+    cta: {
+      title: "Ready to Take the Stress Out of Group Trip Money?",
+      text: "WePlanify's shared budget tracker lets your group log expenses in real time, see who owes what, and settle up cleanly at the end — all in the same app where you build your itinerary, run polls, and coordinate packing.",
+      button: "Start Tracking Together",
+    },
+
+    discoverMore: "Discover More",
+    readMore: "Read more",
+  },
+
+  fr: {
+    readTime: "9 min de lecture",
+    heroTag: "Argent & Voyage 2026",
+    h1: "Budget Voyage de Groupe : Comment Partager les Frais Sans Galère",
+    intro:
+      "Demandez à quelqu'un qui a voyagé en groupe de quatre personnes ou plus quelle a été la partie la plus difficile, et l'argent ressortira dans les trois premières réponses. Pas les vols, pas l'hébergement — l'argent. Qui a payé le dîner, qui doit encore quarante euros, pourquoi quelqu'un commande des cocktails à douze euros alors que les autres divisent l'addition. Le budget d'un voyage de groupe n'a pas à être une source de conflit. Avec un bon système en place avant le départ, ça devient presque invisible. Ce guide couvre tout : fixer un budget réaliste, répartir les frais de manière équitable, suivre les dépenses en temps réel, et solder les comptes proprement à la fin du voyage.",
+
+    tocTitle: "Sommaire",
+    toc: [
+      { id: "money-mess", label: "Pourquoi l'argent tourne toujours au chaos" },
+      { id: "set-budget-early", label: "Fixer le budget avant de réserver quoi que ce soit" },
+      { id: "split-by-category", label: "Diviser par catégorie, pas par tout" },
+      { id: "one-payer-system", label: "Le système du payeur tournant" },
+      { id: "track-real-time", label: "Suivre en temps réel, pas à la fin" },
+      { id: "unequal-budgets", label: "Gérer les budgets inégaux dans le groupe" },
+      { id: "settling-up", label: "Solder les comptes : la méthode propre" },
+      { id: "faq", label: "FAQ" },
+    ],
+
+    sections: {
+      moneyMess: {
+        id: "money-mess",
+        title: "Pourquoi l'Argent en Voyage de Groupe Tourne Toujours au Chaos",
+        paragraphs: [
+          "Ça commence innocemment. Quelqu'un réserve l'Airbnb parce qu'il a la carte avec le meilleur plafond. Un autre achète les billets de train du groupe pour gagner du temps. Un troisième règle le dîner parce que le restaurant n'acceptait qu'un seul paiement. Avant même la fin du voyage, une personne a avancé 700 € et ne sait pas comment demander à se faire rembourser sans passer pour radine.",
+          "Le problème de fond, c'est que les voyages de groupe impliquent des gens avec des revenus différents, des habitudes de dépense différentes, et des idées radicalement différentes de ce que signifie « raisonnable ». Pour un ami, 30 € l'entrée de musée, c'est rien. Pour un autre, c'est une part significative de son budget journalier. Personne n'en parle avant le départ, alors chaque décision de dépense devient une négociation silencieuse où quelqu'un finit toujours par se sentir coupable ou frustré.",
+          "Ensuite, il y a le problème du suivi. Personne ne veut être la personne qui tape furieusement des dépenses dans un tableur pendant que tout le monde profite du coucher de soleil. Alors rien n'est enregistré. Le dernier jour, la moitié des transactions sont oubliées et l'autre moitié sont contestées. Solder les comptes devient un exercice archéologique d'une heure — et c'est exactement le moment où les voyages parfaitement agréables tournent mal.",
+          "La solution n'est pas un système comptable compliqué. C'est un accord simple, pris avant le départ, sur trois choses : combien dépenser par personne, quels frais partager et lesquels payer individuellement, et comment tout enregistrer au fil de l'eau. Ces trois choses bien faites, et l'argent cesse d'être une source de tension.",
+        ],
+      },
+
+      setBudgetEarly: {
+        id: "set-budget-early",
+        title: "Fixer le Budget Avant de Réserver Quoi Que Ce Soit",
+        paragraphs: [
+          "La conversation sur l'argent doit avoir lieu avant de réserver quoi que ce soit — avant l'Airbnb, avant les vols, avant que quelqu'un achète des billets de train ou commence à comparer des menus de restaurant. Une fois que l'argent est dépensé, le budget n'est plus théorique. Les chiffres réels créent une pression réelle, et les gens qui auraient parlé en phase de planification commencent à se taire pour éviter le conflit.",
+          "La façon la plus simple d'ouvrir la conversation, c'est par des fourchettes. Plutôt que de demander « combien tu veux dépenser ? », ce qui force les gens à annoncer un chiffre et à se sentir jugés, présentez trois options : un voyage léger (600–900 € par personne tout compris), un voyage confortable (1 000–1 400 €), un voyage généreux (1 800 € et plus). Demandez à chacun de choisir en privé la fourchette qui lui convient. Si le groupe se concentre autour d'une fourchette, vous avez votre budget. S'il y a un grand écart, c'est un signal important à traiter tôt — pas le troisième jour quand quelqu'un commande un plat à 38 €.",
+          "Une fois que vous avez un total approximatif par personne, décomposez-le par catégorie. Une répartition réaliste pour 7 jours pourrait ressembler à : hébergement (30–35 % du budget), transport incluant avions et déplacements locaux (30–40 %), nourriture et boissons (20–25 %), activités et expériences (10–15 %), et une marge pour les imprévus (5–10 %). Avoir ces catégories par écrit, même dans une note partagée, signifie que tout le monde calibre ses attentes sur les mêmes bases.",
+          "Utilisez la fonctionnalité de sondages de groupe de WePlanify pour voter sur les options d'hébergement et les activités avant de vous engager. Quand tout le groupe décide ensemble ce qu'il faut inclure dans le budget, il n'y a pas une seule personne à blâmer si quelque chose s'avère cher — et tout le monde se sent propriétaire du plan. Les décisions prises démocratiquement sont plus facilement acceptées, y compris les financières.",
+        ],
+      },
+
+      splitByCategory: {
+        id: "split-by-category",
+        title: "Diviser par Catégorie, Pas par Tout",
+        paragraphs: [
+          "Une des erreurs les plus courantes des groupes est d'essayer de partager absolument toutes les dépenses à égalité — ou, à l'inverse, que chacun paie pour lui-même tout le temps. Les deux extrêmes créent des frictions. Le premier mène au ressentiment quand la consommation est inégale. Le second donne à chaque repas l'impression d'une transaction et va à l'encontre de l'intérêt de voyager ensemble.",
+          "L'approche plus intelligente consiste à diviser par catégorie. Certains frais sont genuinement partagés et doivent être divisés à égalité. D'autres sont personnels et doivent être payés individuellement. Tracer cette ligne clairement avant le voyage supprime 90 % des conversations gênantes.",
+          "Les catégories ci-dessous constituent un cadre de départ éprouvé. Adaptez-les à votre groupe, mais l'essentiel est de les convenir avant de partir.",
+        ],
+        categories: [
+          {
+            title: "À diviser à égalité (frais partagés)",
+            items: [
+              "Hébergement — Airbnb, hôtel, dortoir d'auberge. Tout le monde en bénéficie de la même façon quelle que soit la taille de la chambre.",
+              "Transport de groupe — voiture de location, billets de train réservés ensemble, transferts aéroport pour tout le groupe.",
+              "Activités de groupe — visites guidées, entrées de musée, billets pour des expériences auxquelles tout le groupe participe.",
+              "Courses pour les repas partagés — si le groupe cuisine ensemble, divisez la note du supermarché.",
+            ],
+          },
+          {
+            title: "À payer individuellement (frais personnels)",
+            items: [
+              "Repas personnels quand le groupe mange dans des restaurants différents ou commande des choses différentes.",
+              "Boissons personnelles — surtout l'alcool, dont la consommation varie énormément.",
+              "Souvenirs, achats personnels, et tout ce qui ne bénéficie qu'à une seule personne.",
+              "Transport personnel — taxis pour une activité séparée, excursions en solo.",
+            ],
+          },
+        ],
+      },
+
+      onePayerSystem: {
+        id: "one-payer-system",
+        title: "Le Système du Payeur Tournant",
+        paragraphs: [
+          "Diviser l'addition au moment du paiement — tout le monde fouillant ses poches pendant que le serveur attend — c'est lent, gênant et source d'erreurs. Une approche bien plus propre est le système du payeur tournant : une personne paie pour une dépense partagée, l'enregistre immédiatement dans un suivi partagé, et le groupe solde les comptes à la fin du voyage.",
+          "Le mot clé, c'est « immédiatement ». Le système ne fonctionne que si la personne qui paie l'enregistre sur le moment, avant que quiconque soit passé à autre chose ou ait oublié le montant. Cela signifie avoir un outil de suivi de budget partagé ouvert et accessible en permanence — pas une note mentale pour l'ajouter au tableur plus tard. Le suivi de budget partagé de WePlanify est conçu exactement pour ça : une pression pour enregistrer une nouvelle dépense, sélectionner qui a payé et pour qui, et tout le monde le voit instantanément.",
+          "Pour que les choses restent équitables, faites tourner qui paie au fil du voyage. Une personne couvre le dîner, une autre couvre l'activité suivante, une troisième couvre les billets de musée. Si les montants sont enregistrés avec précision, les déséquilibres s'équilibreront à la fin — et s'ils ne le font pas, le règlement final sera quelques virements plutôt qu'un exercice comptable forensique.",
+          "Une règle simple : si vous payez quelque chose de partagé et ne l'enregistrez pas dans les cinq minutes, vous l'avez probablement perdu. Établissez cette habitude tôt, dès le premier jour, pour qu'elle devienne automatique.",
+        ],
+      },
+
+      trackRealTime: {
+        id: "track-real-time",
+        title: "Suivre en Temps Réel, Pas à la Fin",
+        paragraphs: [
+          "Chaque groupe qui a attendu la dernière nuit pour « régler l'argent » l'a regretté. Les souvenirs sont peu fiables, les montants sont arrondis, et quelqu'un finit toujours par avoir l'impression d'avoir plus contribué que ce que les chiffres montrent. La dernière soirée d'un voyage est le pire moment pour une réconciliation financière — tout le monde est fatigué, certains calculent déjà leur vol, et la bonne volonté émotionnelle du voyage est à son plus fragile.",
+          "Le suivi en temps réel résout cela complètement. Quand chaque dépense est enregistrée au moment où elle se produit, il n'y a pas de réconciliation à faire à la fin. Les chiffres sont déjà là. Tout le monde a suivi le total courant tout au long du voyage, donc rien n'est une surprise. Le règlement final est une formalité, pas une négociation.",
+          "La contrainte pratique est un outil de suivi que tout le monde peut voir et alimenter depuis son téléphone. Un tableur partagé fonctionne techniquement mais nécessite un niveau de discipline et de convivialité mobile que la plupart des groupes ne maintiennent pas. Des outils dédiés comme le suivi de budget de WePlanify sont conçus pour ça : ajouter une dépense en dix secondes, voir qui doit quoi en temps réel, obtenir un résumé de règlement à tout moment. Ça supprime le frottement qui pousse les gens à arrêter de suivre.",
+          "Prenez l'habitude d'un bilan quotidien ou tous les deux jours où quelqu'un regarde les totaux en cours et signale les dépenses manquantes. Sur un voyage de 7 jours, une révision de deux minutes tous les deux jours comble les lacunes et maintient tout le monde aligné. Ça construit aussi une conscience collective de la situation financière du voyage — pour que personne ne soit surpris à la fin.",
+          "Pour les road trips en particulier, enregistrez le carburant et les péages comme une dépense partagée dès le début. Les frais d'essence peuvent atteindre 200–400 € pour un road trip d'une semaine et sont faciles à oublier si le conducteur continue de payer en supposant qu'il sera remboursé plus tard. Enregistrez chaque plein immédiatement. Consultez notre guide de planification de road trip pour des conseils plus spécifiques sur la gestion des frais partagés sur la route.",
+        ],
+      },
+
+      unequalBudgets: {
+        id: "unequal-budgets",
+        title: "Gérer les Budgets Inégaux dans le Groupe",
+        paragraphs: [
+          "Presque chaque groupe d'amis a au moins une personne dans une situation financière différente des autres. Peut-être qu'elle est entre deux emplois, qu'elle économise pour quelque chose d'important, ou qu'elle gagne simplement moins. C'est normal, et ça ne veut pas dire qu'elle doit être exclue — mais ça demande un peu de conception intentionnelle dans la structure du voyage.",
+          "La première règle est de créer l'espace pour cette conversation avant le voyage, pas pendant. Si vous savez que quelqu'un dans le groupe a un budget plus serré, contactez-le en privé et demandez quelle fourchette lui convient. Ce n'est pas de la charité — c'est une bonne dynamique de groupe. Un voyage où une personne est stressée par l'argent en permanence est pire pour tout le monde.",
+          "Pour l'hébergement, cherchez des options où le coût ne varie pas selon les individus. Louer une maison ou un grand Airbnb et le diviser à égalité est souvent moins cher par personne que des chambres d'hôtel individuelles, et ça signifie que personne ne paie plus qu'un autre pour sa situation de sommeil. Quand tout le monde est dans le même espace, il n'y a pas de système de niveaux visible.",
+          "Pour les repas et les activités, concevez un mélange. Planifiez des repas de groupe dans des restaurants de gamme moyenne où l'addition se divise facilement, et faites du paiement individuel la norme pour tout ce qui est plus haut de gamme. Si le groupe veut faire une activité chère — un cours de cuisine, une sortie en bateau, un dîner gastronomique — rendez-la optionnelle et prévoyez une alternative tout aussi bonne pour ceux qui passent. Cette structure signifie que personne ne doit se justifier ou se sentir dans le collimateur.",
+          "Une technique pratique : au début du voyage, convenez d'un plafond de dépenses partagées journalier par personne. Quelque chose comme 50 €/jour couvre la part d'hébergement, le transport partagé et un repas de groupe. Tout ce qui dépasse est un choix individuel et un coût individuel. Ce plafond crée un plancher prévisible auquel tout le monde peut s'engager, tout en laissant de la place à ceux qui veulent dépenser plus de le faire librement.",
+        ],
+      },
+
+      settlingUp: {
+        id: "settling-up",
+        title: "Solder les Comptes : la Méthode Propre",
+        paragraphs: [
+          "Le moment idéal pour solder les comptes, c'est avant de partir pour l'aéroport ou le lendemain du retour — pendant que le voyage est encore frais, que les chiffres sont encore visibles, et que la bonne volonté est encore intacte. Attendre une semaine ou plus crée des frictions : les gens s'occupent, les souvenirs s'estompent, et une dette de 40 € commence à sembler soit trop petite pour en parler, soit trop grande pour l'ignorer.",
+          "L'objectif du règlement est de minimiser le nombre de virements. Si six personnes doivent des montants différents à des personnes différentes, l'approche naïve nécessiterait jusqu'à quinze transactions séparées. Un outil de suivi intelligent calcule le nombre minimum de virements nécessaires pour ramener tout le monde à zéro — généralement deux ou trois par personne pour un voyage de groupe classique.",
+          "Voici comment lire le règlement final : l'outil affiche un solde net pour chaque personne — positif signifie qu'on lui doit de l'argent, négatif signifie qu'elle en doit. L'algorithme de règlement trouve ensuite le chemin le plus efficace de chaque solde négatif vers chaque solde positif. La personne A doit 85 € et la personne B est créancière de 90 € : A paie B 85 €. Terminé. La personne C est créancière de 40 €, la personne D doit 15 €, la personne E doit 25 € : D paie C 15 €, E paie C 25 €. Trois transactions au lieu d'un enchevêtrement.",
+          "Le règlement fonctionne mieux quand chacun confirme la réception de son virement le jour même. Un simple message dans le groupe — « viré 85 €, c'est bon » — clôture la boucle publiquement et évite à quiconque de se demander s'il faut relancer. Dans les 48 heures suivant la fin du voyage, chaque solde devrait être à zéro.",
+          "Une dernière note : faites le règlement avant que les souvenirs de qui a payé quoi ne commencent à s'estomper. La clarté financière à la fin d'un voyage, c'est ce qui vous donne vraiment envie de repartir avec ces personnes.",
+        ],
+      },
+    },
+
+    faq: {
+      title: "Questions Fréquentes",
+      items: [
+        {
+          q: "Comment répartir les frais de voyage équitablement entre amis ?",
+          a: "L'approche la plus équitable est de diviser les frais partagés (hébergement, transport de groupe, activités collectives) à égalité, et de laisser chacun payer individuellement ses dépenses personnelles comme les repas individuels et les boissons. Convenez de ces catégories avant le voyage, enregistrez chaque dépense partagée au fil de l'eau avec un outil partagé, et soldez les comptes à la fin selon qui a payé quoi. Cela évite les deux extrêmes : tout diviser à égalité (ce qui pénalise les petits consommateurs) ou chacun pour soi (ce qui donne une impression de transaction permanente).",
+        },
+        {
+          q: "Quelle est la meilleure appli pour suivre les dépenses en groupe ?",
+          a: "Pour une expérience de voyage de groupe complète, le suivi de budget intégré de WePlanify est conçu spécifiquement pour les groupes de voyageurs — il enregistre les dépenses en temps réel, suit qui a payé et qui a participé, et calcule un règlement à la fin. Splitwise est le meilleur outil de partage de dépenses pur et gère bien les devises multiples. L'essentiel est d'utiliser quelque chose que tout le monde dans le groupe ouvrira vraiment sur son téléphone. Un outil que trois personnes sur six utilisent est pire qu'un outil plus simple que les six utilisent régulièrement.",
+        },
+        {
+          q: "Tout le monde doit-il payer la même chose en voyage de groupe ?",
+          a: "Pour les frais partagés comme l'hébergement et le transport de groupe, oui — diviser à égalité est le plus juste parce que tout le monde en bénéficie de la même façon. Pour les dépenses personnelles comme les repas individuels, les boissons et les activités, non — chacun doit payer pour lui-même. La solution pratique est de suivre les dépenses partagées dans une cagnotte commune et de laisser les dépenses personnelles être individuelles. S'il y a des différences de revenus significatives dans le groupe, fixez un plafond journalier pour les dépenses partagées que tout le monde peut confortablement assumer, et laissez les individus qui dépensent plus couvrir leurs extras eux-mêmes.",
+        },
+        {
+          q: "Comment gérer quelqu'un qui ne rembourse pas sa part ?",
+          a: "La prévention vaut mieux que la guérison : utilisez un outil de suivi partagé que tout le monde peut voir pour que les soldes soient transparents tout au long du voyage, pas seulement à la fin. Quand quelqu'un peut voir en temps réel qu'il doit 150 €, il est plus susceptible d'agir avant que ça devienne un montant plus important. Si quelqu'un ne peut vraiment pas payer après le voyage, abordez-le en privé et directement — pas dans le groupe. Fixez une échéance précise (« tu peux envoyer ça d'ici dimanche ? ») plutôt qu'un vague « quand tu peux ». Pour les voyages futurs, certains groupes demandent à chacun de contribuer à une cagnotte commune avant le départ, ce qui évite tout règlement à la fin.",
+        },
+        {
+          q: "Quels frais partager à égalité et lesquels payer individuellement ?",
+          a: "À partager à égalité : hébergement, voitures de location, transport de groupe (trains, transferts aéroport), courses pour les repas collectifs, et toute activité à laquelle tout le groupe participe ensemble. À payer individuellement : repas personnels au restaurant, boissons alcoolisées, souvenirs, transport personnel (un taxi solo, une activité supplémentaire), et tout ce qui ne bénéficie qu'à une seule personne. La règle générale : si ce serait bizarre qu'une personne n'y participe pas, divisez. Si c'est un choix personnel, payez-le vous-même.",
+        },
+        {
+          q: "Quand solder les comptes en voyage de groupe ?",
+          a: "Idéalement le dernier jour du voyage ou dans les 24 à 48 heures suivant le retour, pendant que tout est encore frais et que la bonne volonté du voyage est intacte. Utilisez un outil de suivi qui calcule le nombre minimum de virements nécessaires — ça garde les choses rapides et indolores. Confirmez chaque paiement dans le groupe pour que tout le monde sache quand son solde est soldé. Attendre plus d'une semaine rend la conversation plus difficile et les chiffres plus flous. Fixez une échéance ferme en groupe avant de partir.",
+        },
+      ],
+    },
+
+    cta: {
+      title: "Prêt à gérer le budget de votre voyage sans stress ?",
+      text: "Le suivi de budget partagé de WePlanify permet à votre groupe d'enregistrer les dépenses en temps réel, de voir qui doit quoi, et de solder les comptes proprement — le tout dans la même appli où vous construisez votre itinéraire, lancez des sondages et coordonnez les bagages.",
+      button: "Commencer à suivre ensemble",
+    },
+
+    discoverMore: "Découvrir aussi",
+    readMore: "En savoir plus",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// JSON-LD Schemas
+// ---------------------------------------------------------------------------
+
+function BreadcrumbJsonLd({ locale }: { locale: string }) {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: locale === "fr" ? "Accueil" : "Home",
+        item: `${SITE_URL}/${locale}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: `${SITE_URL}/${locale}/blog`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name:
+          locale === "fr"
+            ? "Budget voyage de groupe"
+            : "Group trip budget",
+        item: `${SITE_URL}/${locale}${locale === "fr" ? PATHNAME_FR : PATHNAME_EN}`,
+      },
+    ],
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
+function FaqJsonLd({ locale }: { locale: string }) {
+  const c = locale === "fr" ? content.fr : content.en;
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: c.faq.items.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.a,
+      },
+    })),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
+function ArticleJsonLd({ locale }: { locale: string }) {
+  const c = locale === "fr" ? content.fr : content.en;
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: c.h1,
+    description: locale === "fr" ? meta.fr.description : meta.en.description,
+    author: {
+      "@type": "Organization",
+      name: "WePlanify",
+      url: SITE_URL,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "WePlanify",
+      url: SITE_URL,
+    },
+    datePublished: "2026-04-15",
+    dateModified: "2026-04-15",
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `${SITE_URL}/${locale}${locale === "fr" ? PATHNAME_FR : PATHNAME_EN}`,
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page Component
+// ---------------------------------------------------------------------------
+
+export default async function GroupTripBudgetPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const c = locale === "fr" ? content.fr : content.en;
+
+  const [navData, navigationData, footerData]: [
+    NavType,
+    Navigation | null,
+    FooterType | null,
+  ] = await Promise.all([
+    sanityFetch<NavType>({
+      query: navQuery,
+      params: { locale },
+      tags: ["nav"],
+    }),
+    sanityFetch<Navigation>({
+      query: navigationQuery,
+      params: { locale },
+      tags: ["navigation"],
+    }),
+    sanityFetch<FooterType>({
+      query: footerQuery,
+      params: { locale },
+      tags: ["footer"],
+    }),
+  ]);
+
+  return (
+    <>
+      <AuthorJsonLd />
+      <BreadcrumbJsonLd locale={locale} />
+      <FaqJsonLd locale={locale} />
+      <ArticleJsonLd locale={locale} />
+
+      <Nav navData={navData} navigationData={navigationData} />
+
+      <main className="min-h-screen bg-[#FFFBF5]">
+        {/* Hero */}
+        <header className="pt-[120px] lg:pt-[140px] pb-12 lg:pb-16 px-4 lg:px-8">
+          <div className="max-w-3xl mx-auto">
+            <div className="hidden lg:block mb-6">
+              <Breadcrumb
+                items={[
+                  {
+                    label: locale === "fr" ? "Accueil" : "Home",
+                    href: `/${locale}`,
+                  },
+                  {
+                    label: "Blog",
+                    href: `/${locale}/blog`,
+                  },
+                  {
+                    label:
+                      locale === "fr"
+                        ? "Budget voyage de groupe"
+                        : "Group trip budget",
+                  },
+                ]}
+              />
+            </div>
+            <span className="inline-block bg-[#EEF899] text-[#001E13] text-sm font-karla font-semibold px-4 py-1.5 rounded-full mb-6">
+              {c.heroTag}
+            </span>
+            <h1 className="text-[#001E13] text-3xl lg:text-[44px] font-londrina-solid leading-tight mb-4">
+              {c.h1}
+            </h1>
+            <p className="text-[#001E13]/60 text-sm font-karla mb-6">
+              {c.readTime}
+            </p>
+            <p className="text-[#001E13]/80 text-base lg:text-lg font-karla leading-relaxed">
+              {c.intro}
+            </p>
+          </div>
+        </header>
+
+        {/* Author */}
+        <div className="max-w-3xl mx-auto px-4 lg:px-8">
+          <AuthorBio
+            locale={locale}
+            publishedDate="2026-04-15"
+            modifiedDate="2026-04-15"
+          />
+        </div>
+
+        {/* Table of Contents */}
+        <nav aria-label={c.tocTitle} className="py-10 lg:py-12 px-4 lg:px-8">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="text-[#001E13] text-xl lg:text-2xl font-londrina-solid mb-5">
+              {c.tocTitle}
+            </h2>
+            <ol className="space-y-2">
+              {c.toc.map((item) => (
+                <li key={item.id}>
+                  <a
+                    href={`#${item.id}`}
+                    className="text-[#001E13]/70 hover:text-[#F6391A] font-karla text-sm lg:text-base transition-colors"
+                  >
+                    {item.label}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </nav>
+
+        {/* Divider */}
+        <div className="max-w-3xl mx-auto px-4 lg:px-8">
+          <hr className="border-[#001E13]/10" />
+        </div>
+
+        {/* Article Sections */}
+        <article className="py-10 lg:py-14 px-4 lg:px-8">
+          <div className="max-w-3xl mx-auto space-y-16 lg:space-y-20">
+
+            {/* Section 1: Why it gets messy */}
+            <section id={c.sections.moneyMess.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.moneyMess.title}
+              </h2>
+              <div className="space-y-4">
+                {c.sections.moneyMess.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+            </section>
+
+            {/* Section 2: Set budget early */}
+            <section id={c.sections.setBudgetEarly.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.setBudgetEarly.title}
+              </h2>
+              <div className="space-y-4">
+                {c.sections.setBudgetEarly.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+              <div className="mt-6 bg-[#EEF899]/40 border border-[#EEF899] rounded-2xl p-5">
+                <p className="text-[#001E13]/80 text-sm font-karla leading-relaxed">
+                  {locale === "fr"
+                    ? "Conseil : utilisez les sondages de groupe de WePlanify pour voter sur les destinations et les activités et aligner les attentes avant de vous engager sur quoi que ce soit."
+                    : "Tip: use WePlanify's group polls to vote on destinations and activities and align expectations before committing to anything."}{" "}
+                  <Link
+                    href={`/${locale}/features/polls`}
+                    className="text-[#F6391A] font-semibold hover:underline"
+                  >
+                    {locale === "fr" ? "Essayer les sondages" : "Try group polls"} →
+                  </Link>
+                </p>
+              </div>
+            </section>
+
+            {/* Section 3: Split by category */}
+            <section id={c.sections.splitByCategory.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.splitByCategory.title}
+              </h2>
+              <div className="space-y-4 mb-8">
+                {c.sections.splitByCategory.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+              <div className="grid md:grid-cols-2 gap-6">
+                {c.sections.splitByCategory.categories.map((cat, i) => (
+                  <div
+                    key={i}
+                    className="bg-white border border-[#001E13]/10 rounded-2xl p-6"
+                  >
+                    <h3 className="text-[#001E13] text-base font-londrina-solid mb-4">
+                      {cat.title}
+                    </h3>
+                    <ul className="space-y-2">
+                      {cat.items.map((item, j) => (
+                        <li
+                          key={j}
+                          className="text-[#001E13]/70 text-sm font-karla leading-relaxed flex items-start gap-2"
+                        >
+                          <span className={`mt-0.5 flex-shrink-0 font-bold ${i === 0 ? "text-green-600" : "text-[#F6391A]"}`}>
+                            {i === 0 ? "+" : "−"}
+                          </span>
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* Section 4: One-payer system */}
+            <section id={c.sections.onePayerSystem.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.onePayerSystem.title}
+              </h2>
+              <div className="space-y-4">
+                {c.sections.onePayerSystem.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+            </section>
+
+            {/* Section 5: Track in real time */}
+            <section id={c.sections.trackRealTime.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.trackRealTime.title}
+              </h2>
+              <div className="space-y-4">
+                {c.sections.trackRealTime.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+              <div className="mt-6 bg-white border border-[#001E13]/10 rounded-2xl p-5">
+                <p className="text-[#001E13]/80 text-sm font-karla leading-relaxed">
+                  {locale === "fr"
+                    ? "Le suivi de budget partagé de WePlanify permet à chaque membre du groupe d'ajouter des dépenses en quelques secondes, depuis n'importe quel appareil."
+                    : "WePlanify's shared budget tracker lets every group member add expenses in seconds, from any device."}{" "}
+                  <Link
+                    href={`/${locale}/features/budget`}
+                    className="text-[#F6391A] font-semibold hover:underline"
+                  >
+                    {locale === "fr" ? "Voir le suivi de budget" : "See the budget tracker"} →
+                  </Link>
+                </p>
+              </div>
+            </section>
+
+            {/* Section 6: Unequal budgets */}
+            <section id={c.sections.unequalBudgets.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.unequalBudgets.title}
+              </h2>
+              <div className="space-y-4">
+                {c.sections.unequalBudgets.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+            </section>
+
+            {/* Section 7: Settling up */}
+            <section id={c.sections.settlingUp.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.settlingUp.title}
+              </h2>
+              <div className="space-y-4">
+                {c.sections.settlingUp.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+            </section>
+
+          </div>
+        </article>
+
+        {/* Divider */}
+        <div className="max-w-3xl mx-auto px-4 lg:px-8">
+          <hr className="border-[#001E13]/10" />
+        </div>
+
+        {/* FAQ */}
+        <section id="faq" className="py-12 lg:py-16 px-4 lg:px-8 bg-white">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid mb-8">
+              {c.faq.title}
+            </h2>
+            <div className="space-y-6">
+              {c.faq.items.map((item, i) => (
+                <details
+                  key={i}
+                  className="group border-b border-[#001E13]/10 pb-5"
+                >
+                  <summary className="flex items-start justify-between cursor-pointer list-none font-karla font-semibold text-[#001E13] text-base lg:text-lg">
+                    <span className="pr-4">{item.q}</span>
+                    <span className="text-[#F6391A] text-xl leading-none mt-0.5 group-open:rotate-45 transition-transform">
+                      +
+                    </span>
+                  </summary>
+                  <p className="mt-3 text-[#001E13]/70 text-sm lg:text-base font-karla leading-relaxed">
+                    {item.a}
+                  </p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Discover More */}
+        <section className="py-16 lg:py-20 px-4 lg:px-8 bg-[#FFFBF5]">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid text-center mb-10">
+              {c.discoverMore}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <Link href={`/${locale}/features/budget`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 hover:shadow-lg transition-shadow duration-300 h-full">
+                  <h3 className="text-lg font-londrina-solid text-[#001E13] mb-2">
+                    {locale === "fr" ? "Suivi de Budget Partagé" : "Shared Budget Tracker"}
+                  </h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">
+                    {locale === "fr"
+                      ? "Enregistrez les dépenses en temps réel, voyez qui doit quoi, et soldez les comptes proprement avec WePlanify."
+                      : "Log expenses in real time, see who owes what, and settle up cleanly with WePlanify's group budget tracker."}
+                  </p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">
+                    {locale === "fr" ? "Découvrir le tracker" : "Explore the tracker"} →
+                  </span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/trip-with-friends`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 hover:shadow-lg transition-shadow duration-300 h-full">
+                  <h3 className="text-lg font-londrina-solid text-[#001E13] mb-2">
+                    {locale === "fr" ? "Voyage entre Amis" : "Trip with Friends"}
+                  </h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">
+                    {locale === "fr"
+                      ? "Organisez un voyage de groupe entre amis facilement — itinéraire, sondages, budget et bagages au même endroit."
+                      : "Plan a group trip with friends effortlessly — itinerary, polls, budget, and packing all in one place."}
+                  </p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">
+                    {c.readMore} →
+                  </span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/guides/plan-group-trip`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 hover:shadow-lg transition-shadow duration-300 h-full">
+                  <h3 className="text-lg font-londrina-solid text-[#001E13] mb-2">
+                    {locale === "fr" ? "Guide : Organiser un Voyage de Groupe" : "Guide: Plan a Group Trip"}
+                  </h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">
+                    {locale === "fr"
+                      ? "Le guide complet pour organiser un voyage de groupe de A à Z, de la destination au départ."
+                      : "The complete guide to planning a group trip from destination choice to departure day."}
+                  </p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">
+                    {c.readMore} →
+                  </span>
+                </div>
+              </Link>
+              <Link
+                href={`/${locale}/blog/meilleures-applications-voyage-groupe`}
+                className="group"
+              >
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 hover:shadow-lg transition-shadow duration-300 h-full">
+                  <h3 className="text-lg font-londrina-solid text-[#001E13] mb-2">
+                    {locale === "fr"
+                      ? "Meilleures Applis Voyage de Groupe"
+                      : "Best Group Trip Planner Apps"}
+                  </h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">
+                    {locale === "fr"
+                      ? "Comparatif honnête des meilleures applications pour planifier un voyage de groupe en 2026."
+                      : "An honest comparison of the best apps to plan a group trip in 2026."}
+                  </p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">
+                    {c.readMore} →
+                  </span>
+                </div>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="py-16 lg:py-20 px-4 lg:px-8">
+          <div className="max-w-3xl mx-auto text-center">
+            <div className="bg-[#F6391A] rounded-3xl p-8 lg:p-14">
+              <h2 className="text-[#FFFBF5] text-2xl lg:text-4xl font-londrina-solid mb-4">
+                {c.cta.title}
+              </h2>
+              <p className="text-[#FFFBF5]/90 text-sm lg:text-base font-karla leading-relaxed mb-8 max-w-xl mx-auto">
+                {c.cta.text}
+              </p>
+              <Link
+                href="https://app.weplanify.com"
+                className="inline-block bg-[#001E13] hover:bg-[#001E13]/85 text-[#FFFBF5] font-karla font-bold text-sm lg:text-base px-8 py-3.5 rounded-full transition-colors"
+              >
+                {c.cta.button}
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer footerData={footerData} />
+    </>
+  );
+}

--- a/src/app/[locale]/blog/organiser-evjf/page.tsx
+++ b/src/app/[locale]/blog/organiser-evjf/page.tsx
@@ -1,0 +1,1236 @@
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import Link from "next/link";
+import { sanityFetch } from "@/sanity/lib/fetch";
+import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
+import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
+import { setRequestLocale } from "next-intl/server";
+import { routing } from "@/i18n/routing";
+import { Metadata } from "next";
+import Breadcrumb from "@/components/Breadcrumb";
+import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
+
+// ---------------------------------------------------------------------------
+// Static params
+// ---------------------------------------------------------------------------
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+const SITE_URL = "https://www.weplanify.com";
+const PATHNAME_FR = "/blog/organiser-evjf";
+const PATHNAME_EN = "/blog/how-to-plan-bachelorette-party";
+
+const meta = {
+  en: {
+    title: "How to Plan a Bachelorette Party — Complete Guide 2026",
+    description:
+      "Everything you need to plan the perfect bachelorette trip: destination ideas, budget splitting, activities, and keeping everyone happy.",
+  },
+  fr: {
+    title: "Comment Organiser un EVJF : Guide Complet 2026",
+    description:
+      "Tout ce qu'il faut savoir pour organiser un EVJF réussi : destination, budget partagé, idées d'activités et coordination du groupe.",
+  },
+};
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const l = locale === "fr" ? meta.fr : meta.en;
+  const pathname = locale === "fr" ? PATHNAME_FR : PATHNAME_EN;
+  const currentUrl = `${SITE_URL}/${locale}${pathname}`;
+
+  return {
+    title: l.title,
+    description: l.description,
+    authors: [{ name: "WePlanify" }],
+    openGraph: {
+      type: "article",
+      locale: locale === "fr" ? "fr_FR" : "en_US",
+      url: currentUrl,
+      siteName: "WePlanify",
+      title: l.title,
+      description: l.description,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: l.title,
+      description: l.description,
+    },
+    alternates: {
+      canonical: currentUrl,
+      languages: {
+        en: `${SITE_URL}/en${PATHNAME_EN}`,
+        fr: `${SITE_URL}/fr${PATHNAME_FR}`,
+        "x-default": `${SITE_URL}/en${PATHNAME_EN}`,
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Content
+// ---------------------------------------------------------------------------
+
+type ContentLocale = {
+  readTime: string;
+  heroTag: string;
+  h1: string;
+  intro: string;
+  tocTitle: string;
+  toc: { id: string; label: string }[];
+  sections: {
+    whyHard: {
+      id: string;
+      title: string;
+      paragraphs: string[];
+    };
+    fourQuestions: {
+      id: string;
+      title: string;
+      intro: string;
+      questions: { title: string; text: string }[];
+    };
+    destinationTypes: {
+      id: string;
+      title: string;
+      intro: string;
+      types: { title: string; text: string; bestFor: string }[];
+    };
+    budgetConversation: {
+      id: string;
+      title: string;
+      paragraphs: string[];
+      tips: { title: string; text: string }[];
+    };
+    timeline: {
+      id: string;
+      title: string;
+      intro: string;
+      steps: { when: string; tasks: string[] }[];
+    };
+    activities: {
+      id: string;
+      title: string;
+      paragraphs: string[];
+      ideas: { category: string; items: string[] }[];
+      outro: string;
+    };
+  };
+  faq: {
+    title: string;
+    items: { q: string; a: string }[];
+  };
+  cta: {
+    title: string;
+    text: string;
+    button: string;
+  };
+  discoverMore: string;
+  readMore: string;
+};
+
+const content: { en: ContentLocale; fr: ContentLocale } = {
+  en: {
+    readTime: "9 min read",
+    heroTag: "Complete Guide 2026",
+    h1: "How to Plan a Bachelorette Party — Complete Guide 2026",
+    intro:
+      "On paper, a bachelorette party sounds straightforward: gather the bride's closest friends, pick a destination, have a great time. In practice, you are coordinating six to twelve people with wildly different schedules, budgets, tastes, and opinions on what counts as a good time — all while trying to keep the bride blissfully unaware of the behind-the-scenes chaos. This guide cuts through the noise and gives you a real framework for planning a bachelorette trip that people will actually enjoy, not just survive.",
+
+    tocTitle: "Table of Contents",
+    toc: [
+      { id: "why-hard", label: "Why Bachelorette Planning Is Harder Than It Looks" },
+      { id: "four-questions", label: "The Four Questions to Settle First" },
+      { id: "destination-types", label: "Destination Types" },
+      { id: "budget-conversation", label: "The Budget Conversation Nobody Wants to Have" },
+      { id: "timeline", label: "Planning Timeline" },
+      { id: "activities", label: "Activities" },
+      { id: "faq", label: "FAQ" },
+    ],
+
+    sections: {
+      whyHard: {
+        id: "why-hard",
+        title: "Why Bachelorette Planning Is Harder Than It Looks",
+        paragraphs: [
+          "The problem is not logistics — it is people. A bachelorette party brings together women who may barely know each other, united only by their connection to the bride. There is the maid of honor who has strong opinions about everything, the college friend who is on a tight budget and too embarrassed to say so, the work colleague who just found out she is pregnant, and the sister who lives in a different time zone and always replies late to group messages. Managing that social matrix while also booking hotels, planning activities, and chasing down deposits is genuinely exhausting.",
+          "There is also the pressure of perfection. Unlike a regular trip with friends, a bachelorette carries emotional weight. It is supposed to be a milestone, a last hurrah, a memory the bride cherishes forever. That pressure turns minor hiccups — a restaurant that is fully booked, a rainy afternoon, a disagreement about where to eat — into disproportionate stressors. The organizer ends up carrying a load that nobody signed up for.",
+          "The third layer is social dynamics. Pinterest has created an arms race of elaborate bachelorette aesthetics — matching sashes, coordinated pastel outfits, carefully curated itineraries full of instagrammable moments. Not every bride wants this. Not every group can afford it. And sometimes the gap between the Instagram version of the bachelorette and what people actually want to do causes real friction. The fix is brutally honest early conversations — and the right tools to keep the group aligned without turning the planning process itself into a source of conflict.",
+        ],
+      },
+      fourQuestions: {
+        id: "four-questions",
+        title: "Start Here: The Four Questions to Settle First",
+        intro:
+          "Before you look at a single hotel or activity, answer these four questions as a group. They will save you weeks of back-and-forth.",
+        questions: [
+          {
+            title: "Who is actually in the group?",
+            text: "Get the final guest list confirmed before you plan anything else. Every person added after the fact changes the budget math, the accommodation options, and the activity logistics. Be realistic: not everyone who says 'yes' in the initial excitement will follow through. Build a firm deadline for RSVPs — two weeks is plenty — and plan around whoever committed by that date.",
+          },
+          {
+            title: "What is the honest budget range?",
+            text: "Do not set a budget based on what you wish everyone could spend. Ask each person privately what they are comfortable with, find the median, and plan around that number. If there is a wide spread, consider a tiered model: a core itinerary everyone can afford, with optional add-ons for those who want more. Use a shared budget tracker from day one so there are no surprises about what the total will look like per person.",
+          },
+          {
+            title: "What does the bride actually want?",
+            text: "Not what Pinterest says she should want. Not what you would want in her position. Ask her directly, or ask the person who knows her best. Some brides want a wild weekend in Ibiza; others genuinely want a cozy spa retreat with their five closest friends and no sashes in sight. You cannot plan a great bachelorette without knowing this, and assuming you know is the most common mistake organizers make.",
+          },
+          {
+            title: "Weekend or longer?",
+            text: "A three-day weekend is the sweet spot for most groups: long enough to feel like a real trip, short enough that everyone can take time off work and afford it. Five to seven days works for groups with flexible schedules and higher budgets — but more days means more coordination, more meals to plan, and more opportunities for the group dynamic to fray. Unless the bride specifically wants an extended trip, keep it tight.",
+          },
+        ],
+      },
+      destinationTypes: {
+        id: "destination-types",
+        title: "Destination Types",
+        intro:
+          "The destination sets the tone for everything else. Here are the four main categories, what they deliver, and which type of bride each suits best.",
+        types: [
+          {
+            title: "City Break",
+            text: "A long weekend in a vibrant city — Paris, Barcelona, Amsterdam, Lisbon, Nashville, New Orleans — gives the group maximum flexibility. Day activities, nightlife, restaurant options, and cultural experiences are all within reach. City breaks suit groups with mixed tastes because there is always something for everyone. The challenge is that the best cities for bachelorettes are expensive, especially for accommodation with a large group. Book a self-catered apartment rather than multiple hotel rooms — it is cheaper, more sociable, and gives you a base to pre-drink before nights out.",
+            bestFor: "Mixed groups, brides who love culture and nightlife, first-time travelers",
+          },
+          {
+            title: "Beach Escape",
+            text: "Sun, a pool or beach, a villa or hotel. The beach escape is the classic bachelorette format for a reason: it is low-planning-effort, high-enjoyment. The days organize themselves around the pool, meals are easy, and nights can be as relaxed or as lively as the group wants. The Algarve, Mallorca, Mykonos, and the Croatian coast are European favourites. For US groups, Nashville beats Miami on value, but the Florida Keys are hard to beat for a small, close-knit group. The main risk is that beach trips can get repetitive after day two — make sure you have one or two structured activities to anchor the schedule.",
+            bestFor: "Brides who want to relax, sun-loving groups, long weekends",
+          },
+          {
+            title: "Spa Retreat",
+            text: "Not every bachelorette wants a raucous weekend. Some brides genuinely want a spa retreat: massages, infrared saunas, thermal pools, good food, and early nights. This format works brilliantly for smaller, closer groups — four to six people rather than twelve. It is also more budget-predictable than a city break because you are largely staying in one place. The challenge is it requires buy-in from the whole group; if half the guests expect clubs and the other half expect silence, nobody has a good time.",
+            bestFor: "Introverted brides, wellness-focused groups, smaller intimate gatherings",
+          },
+          {
+            title: "Adventure Trip",
+            text: "Surfing in the Basque Country, hiking in Slovenia, a cycling weekend in Tuscany, glamping in Wales. Adventure bachelorettes are growing in popularity because they create shared experiences that bond the group in a way that nightlife rarely does. The stories from the day you all fell off the paddleboards are better than any club night. The catch: adventure trips require more physical planning, insurance considerations, and honest conversations about fitness levels. Do not book a challenging hike and hope everyone can manage it.",
+            bestFor: "Active brides, groups who already spend time outdoors together",
+          },
+        ],
+      },
+      budgetConversation: {
+        id: "budget-conversation",
+        title: "The Budget Conversation Nobody Wants to Have",
+        paragraphs: [
+          "Money is where bachelorette plans fall apart. Not because people are malicious — because organizers often delay the real budget conversation until deposits are due and flights are booked, at which point the person who cannot actually afford it feels trapped and resentful. Having the budget conversation early and explicitly, before any commitments are made, is the single most important thing you can do for the group dynamic.",
+          "The bride traditionally does not pay her share of accommodation and activities — that cost gets split among the guests. Make sure everyone in the group understands this before costs are finalized. On a trip for eight people where the accommodation is €1,500, that is €215 per person rather than €187. Not a lot in absolute terms, but worth being explicit about from the start.",
+          "Centralize what you can. Pre-book accommodation, transfers, and group activities through one person or a shared planning tool so money flows clearly and nobody is left out of pocket for weeks. Use a shared budget tracker so everyone can see the running total — groups that track spending as they go avoid the uncomfortable end-of-trip reconciliation that can sour the last day.",
+        ],
+        tips: [
+          {
+            title: "Set a per-person budget, not a total budget",
+            text: "A total budget of €3,000 sounds manageable until you realise the group is fifteen people and that covers less than €200 each. Always think in per-person terms from the start.",
+          },
+          {
+            title: "Separate must-haves from nice-to-haves",
+            text: "Accommodation and a couple of key activities are non-negotiable. Matching outfits, custom decorations, and elaborate gift bags are optional. Know the difference before you start spending.",
+          },
+          {
+            title: "Handle unequal incomes gracefully",
+            text: "If someone in the group is on a tighter budget, let them contribute differently — hosting a dinner, coordinating logistics, picking up smaller costs — rather than stretching beyond their means or feeling excluded. Generosity works better than awkward subsidy conversations.",
+          },
+          {
+            title: "Use a shared budget tracker from day one",
+            text: "Tools like WePlanify's built-in budget tracker let everyone see what has been paid, what is owed, and what the final per-person cost will be — without anyone having to chase spreadsheets or Venmo requests at the end of the trip.",
+          },
+        ],
+      },
+      timeline: {
+        id: "timeline",
+        title: "Planning Timeline",
+        intro:
+          "Bachelorette planning has a way of expanding to fill whatever time you give it — or compressing into a stressful last-minute scramble if you leave it too late. Here is a realistic timeline that keeps things moving without the chaos.",
+        steps: [
+          {
+            when: "3 months out",
+            tasks: [
+              "Confirm the guest list and get firm RSVPs",
+              "Have the honest budget conversation with the group",
+              "Agree on dates — use a poll to find when everyone is free",
+              "Choose a destination type based on the bride's actual preferences",
+              "Book accommodation (this locks in everything else)",
+              "Start a shared planning space so everyone can see the plan",
+            ],
+          },
+          {
+            when: "6 weeks out",
+            tasks: [
+              "Book transport — flights, train, or group transfer",
+              "Research and shortlist activities — use a group poll to narrow it down",
+              "Book any must-do activities that require advance reservations",
+              "Set up a shared budget tracker and log deposits as they go",
+              "Confirm dietary restrictions and accessibility needs for every guest",
+            ],
+          },
+          {
+            when: "2 weeks out",
+            tasks: [
+              "Send the final itinerary to the group — one clean document, not a thread of messages",
+              "Book restaurants for group dinners",
+              "Buy any decorations or personalised items (sashes, etc.) if using them",
+              "Assign a shared packing list so everyone knows what communal items are covered",
+              "Chase any outstanding payments or RSVPs",
+            ],
+          },
+          {
+            when: "Day before",
+            tasks: [
+              "Confirm accommodation check-in details and share with the group",
+              "Pack a small emergency kit: plasters, painkillers, phone charger, snacks",
+              "Have the budget tracker open and up to date",
+              "Get a good night's sleep — you are going to need it",
+            ],
+          },
+        ],
+      },
+      activities: {
+        id: "activities",
+        title: "Activities",
+        paragraphs: [
+          "The best bachelorette itinerary has a clear structure but plenty of breathing room. Overscheduled trips feel like a school trip; underscheduled ones drift into arguments about what to do next. Aim for one or two anchoring activities per day, with free time built in for spontaneity.",
+          "The golden rule: make sure at least one activity is specifically chosen because the bride loves it, not because it is standard bachelorette fare. If she hates cocktail-making classes but loves pottery, book pottery. If she has never liked club nights but lives for a long, boozy dinner with her favourite people, prioritise that. The Instagram version of the bachelorette is not the point.",
+          "Avoid forced fun. Matching outfits, sashes, and L-plates are fine if the bride is into it — but if she has already mentioned she would be mortified, do not do it. Same with strippers, scavenger hunts, and games based on embarrassing the bride. Fun that requires everyone to perform happiness tends to fall flat.",
+        ],
+        ideas: [
+          {
+            category: "Daytime",
+            items: [
+              "Private sailing or boat trip",
+              "Wine or cocktail tasting (book a private session, not the tourist tour)",
+              "Spa morning with individual treatments",
+              "Pottery, glassblowing, or art workshop",
+              "Paddleboarding, surfing lesson, or kayaking",
+              "Cooking class with a local chef",
+              "Vintage shopping day in a new city",
+            ],
+          },
+          {
+            category: "Evening",
+            items: [
+              "Private chef dinner at your accommodation",
+              "Reservation at the restaurant the bride has been wanting to try",
+              "Cocktail-making class (but only if she actually wants this)",
+              "Karaoke — genuinely underrated for mixed groups",
+              "Night at the opera, jazz club, or a stand-up show",
+              "Casino night (low-stakes, high entertainment value)",
+            ],
+          },
+          {
+            category: "Low-key",
+            items: [
+              "Movie night in the villa with film of the bride's choice",
+              "Board game evening with good wine",
+              "Sunset walk followed by a long dinner",
+              "Morning yoga or pilates session",
+              "Farmers' market brunch",
+            ],
+          },
+        ],
+        outro:
+          "Vote on activities using a group poll before you book anything — it prevents the classic situation where the organizer books something expensive and two people hate it. WePlanify's polls feature takes thirty seconds to set up and gives everyone an equal voice without a sixty-message debate in the group chat.",
+      },
+    },
+
+    faq: {
+      title: "Frequently Asked Questions",
+      items: [
+        {
+          q: "How far in advance should you plan a bachelorette party?",
+          a: "For a weekend trip, three months is comfortable — it gives you enough time to get everyone's dates aligned, book accommodation before prices jump, and organize activities without rush. If you are planning something more elaborate (international flights, villa rental, high-demand destinations), four to five months is safer. For a local night out or a simple staycation, six weeks is usually fine. The biggest mistake is waiting until two months before the wedding, when everyone's schedule is already packed with dress fittings and other wedding events.",
+        },
+        {
+          q: "How do you handle different budgets in the group?",
+          a: "Have the conversation early and privately. Ask each person individually what they are comfortable spending — not in a group message where social pressure skews the answers. Find the median and plan around it. Offer optional add-ons for people who want to spend more, rather than planning an expensive trip and hoping everyone finds a way to manage. If someone genuinely cannot afford the trip as planned, let them contribute differently — coordinating logistics, handling communication, covering a smaller cost — rather than asking them to stretch beyond their means.",
+        },
+        {
+          q: "What is a good bachelorette trip budget per person?",
+          a: "For a UK or European city break, £300 to £600 per person for a three-night trip covers transport, accommodation, and a couple of activities if you are smart about it. Beach or villa trips in southern Europe run €400 to €800 per person for a long weekend. US domestic trips vary wildly — Nashville, Miami, and New York weekends can run $500 to $1,200 per person depending on the group size and accommodation type. Remember: the bride traditionally does not pay her share, so factor that cost into your per-person calculation from the start.",
+        },
+        {
+          q: "How many people is too many for a bachelorette trip?",
+          a: "Eight to ten people is the practical upper limit for a cohesive trip. Above that, restaurant reservations become a nightmare, activities require booking out entire venues, and the group inevitably fragments. Large groups also mean more logistical overhead — more people to coordinate, more variables to manage, more chances for someone to drop out last minute and throw the budget off. If the guest list is genuinely fifteen-plus, consider splitting into two groups with separate trips, or choosing a format that works for large groups by design — a villa with a private chef, a hired boat, a full venue buyout.",
+        },
+        {
+          q: "What if the bride doesn't want a traditional bachelorette?",
+          a: "Plan what she actually wants. There is no rule that says a bachelorette has to involve sashes, strippers, or a club night. If she wants a quiet spa weekend with three friends, that is the bachelorette. If she wants a hiking trip in the mountains, that is the bachelorette. The best way to find out is to ask her directly — or ask her closest friend or sister. The worst bachelorettes are the ones where the organizer planned the trip they wanted to go on rather than what the bride actually cares about.",
+        },
+        {
+          q: "How do you keep everyone happy on a bachelorette trip?",
+          a: "You will not — and trying to will exhaust you. Aim for everyone having a good time most of the time, not universal happiness at every moment. Build variety into the schedule: active and relaxed, group and free time, early nights and later ones. Use polls to make group decisions so nobody feels steamrolled. Set clear expectations upfront about budget, formality, and what is and is not planned. And accept that some people will be harder to please than others — that is true of every group trip, not just bachelorettes.",
+        },
+      ],
+    },
+
+    cta: {
+      title: "Ready to Plan the Perfect Bachelorette Trip?",
+      text: "WePlanify brings your whole group into one place — destination polls, shared itinerary, budget tracker, and packing lists. Stop managing the chaos in a group chat and start actually planning together.",
+      button: "Plan the Bachelorette",
+    },
+
+    discoverMore: "Discover More",
+    readMore: "Read more",
+  },
+
+  fr: {
+    readTime: "9 min de lecture",
+    heroTag: "Guide Complet 2026",
+    h1: "Comment Organiser un EVJF : Guide Complet 2026",
+    intro:
+      "Sur le papier, organiser un EVJF semble simple : réunir les amies proches de la future mariée, choisir une destination, passer un bon moment. En pratique, vous coordonnez six à douze personnes avec des emplois du temps, des budgets, des goûts et des idées du bon temps radicalement différents — tout en essayant que la mariée ne voit rien du chaos qui se passe dans les coulisses. Ce guide va droit au but et vous donne un cadre concret pour organiser un EVJF que tout le monde appréciera vraiment, pas juste endurera.",
+
+    tocTitle: "Sommaire",
+    toc: [
+      { id: "why-hard", label: "Pourquoi Organiser un EVJF est plus Compliqué qu'il n'y Paraît" },
+      { id: "four-questions", label: "Les Quatre Questions à Trancher en Premier" },
+      { id: "destination-types", label: "Types d'EVJF" },
+      { id: "budget-conversation", label: "La Conversation Budget qu'on Évite Toujours" },
+      { id: "timeline", label: "Planning : de l'Idée à la Soirée" },
+      { id: "activities", label: "Les Activités" },
+      { id: "faq", label: "FAQ" },
+    ],
+
+    sections: {
+      whyHard: {
+        id: "why-hard",
+        title: "Pourquoi Organiser un EVJF est plus Compliqué qu'il n'y Paraît",
+        paragraphs: [
+          "Le problème, ce n'est pas la logistique — c'est les gens. Un EVJF réunit des femmes qui se connaissent parfois à peine, unies uniquement par leur lien avec la future mariée. Il y a la témoin qui a un avis sur tout, la copine d'enfance avec un budget serré qu'elle n'osera jamais mentionner, la collègue qui vient d'apprendre qu'elle est enceinte, et la sœur qui habite dans un autre fuseau horaire et répond toujours au dernier moment aux messages de groupe. Gérer cette dynamique sociale tout en réservant des hôtels, planifiant des activités et relançant les acomptes, c'est épuisant.",
+          "S'ajoute à ça la pression de la perfection. Contrairement à un voyage ordinaire entre amies, l'EVJF a un poids émotionnel particulier. C'est censé être un moment marquant, une dernière grande sortie, un souvenir que la mariée chérira toute sa vie. Cette pression transforme les petits imprévus — un restaurant complet, une après-midi pluvieuse, un désaccord sur le dîner — en sources de stress disproportionnées. L'organisatrice porte une charge dont personne ne lui avait parlé.",
+          "La troisième dimension, c'est la pression sociale. Pinterest a créé une surenchère d'esthétiques EVJF élaborées — écharpes coordonnées, tenues pastel assorties, itinéraires instagrammables soigneusement orchestrés. Toutes les futures mariées ne veulent pas ça. Tous les groupes ne peuvent pas se le permettre. Et parfois le fossé entre la version Instagram de l'EVJF et ce que les gens veulent vraiment faire crée de vraies tensions. La solution ? Des conversations honnêtes dès le départ — et les bons outils pour garder le groupe aligné sans que la planification elle-même devienne une source de conflit.",
+        ],
+      },
+      fourQuestions: {
+        id: "four-questions",
+        title: "Les Quatre Questions à Trancher en Premier",
+        intro:
+          "Avant de regarder un seul hôtel ou une seule activité, répondez à ces quatre questions en groupe. Elles vous économiseront des semaines d'allers-retours.",
+        questions: [
+          {
+            title: "Qui est vraiment dans le groupe ?",
+            text: "Confirmez la liste définitive des participantes avant de planifier quoi que ce soit d'autre. Chaque personne ajoutée après coup change le calcul du budget, les options d'hébergement et la logistique des activités. Soyons réalistes : toutes celles qui disent 'oui' dans l'enthousiasme du premier moment ne vont pas nécessairement suivre. Fixez une date limite ferme pour les confirmations — deux semaines, c'est largement suffisant — et planifiez avec celles qui se sont engagées dans ce délai.",
+          },
+          {
+            title: "Quel est le budget honnête de chacune ?",
+            text: "Ne fixez pas un budget basé sur ce que vous aimeriez que tout le monde puisse dépenser. Demandez à chaque personne en privé ce qu'elle est à l'aise de dépenser, trouvez la médiane et planifiez autour de ce chiffre. Si les écarts sont importants, envisagez un modèle modulaire : un programme de base accessible à toutes, avec des options payantes pour celles qui veulent plus. Utilisez un suivi de budget partagé dès le départ pour qu'il n'y ait pas de mauvaises surprises sur le coût total par personne.",
+          },
+          {
+            title: "Ce que la future mariée veut vraiment ?",
+            text: "Pas ce que Pinterest dit qu'elle devrait vouloir. Pas ce que vous voudriez à sa place. Demandez-lui directement, ou demandez à la personne qui la connaît le mieux. Certaines futures mariées veulent un week-end de folie à Ibiza ; d'autres veulent sincèrement un week-end spa tranquille avec leurs cinq amies les plus proches, sans écharpe en vue. On ne peut pas organiser un super EVJF sans connaître sa réponse, et supposer qu'on la connaît est l'erreur la plus courante des organisatrices.",
+          },
+          {
+            title: "Week-end ou plus long ?",
+            text: "Un week-end de trois jours est le format idéal pour la plupart des groupes : assez long pour avoir l'impression d'un vrai voyage, assez court pour que tout le monde puisse poser des congés et se le permettre. Cinq à sept jours peut fonctionner pour les groupes avec des agendas flexibles et des budgets plus importants — mais plus de jours signifie plus de coordination, plus de repas à prévoir et plus d'opportunités pour la dynamique de groupe de se fragiliser. Sauf si la mariée veut spécifiquement un voyage long, restez sur un format court.",
+          },
+        ],
+      },
+      destinationTypes: {
+        id: "destination-types",
+        title: "Types d'EVJF",
+        intro:
+          "La destination donne le ton à tout le reste. Voici les quatre grandes catégories, ce qu'elles apportent, et quel type de future mariée convient à chacune.",
+        types: [
+          {
+            title: "City Break",
+            text: "Un long week-end dans une ville vibrante — Paris, Barcelone, Amsterdam, Lisbonne, Séville — donne au groupe un maximum de flexibilité. Activités de journée, vie nocturne, options de restaurants et expériences culturelles sont toutes à portée de main. Les city breaks conviennent aux groupes aux goûts variés parce qu'il y a toujours quelque chose pour tout le monde. L'enjeu : les meilleures villes pour les EVJF sont chères, surtout en hébergement pour un grand groupe. Réservez un appartement en location entière plutôt que plusieurs chambres d'hôtel — c'est moins cher, plus convivial et vous avez une base pour se préparer ensemble.",
+            bestFor: "Groupes mixtes, futures mariées qui aiment la culture et la vie nocturne",
+          },
+          {
+            title: "Plage",
+            text: "Soleil, piscine ou plage, villa ou hôtel. L'EVJF plage est le format classique pour une bonne raison : il demande peu de planification et délivre beaucoup de plaisir. Les journées s'organisent naturellement autour de la piscine, les repas sont simples, et les soirées peuvent être aussi relaxées ou animées que le groupe le souhaite. L'Algarve, Majorque, Mykonos et la côte croate sont les destinations européennes favorites. Le principal risque avec un séjour plage, c'est la répétition à partir du deuxième jour — prévoyez une ou deux activités structurées pour ancrer le programme.",
+            bestFor: "Futures mariées qui veulent se détendre, groupes amateurs de soleil, week-ends",
+          },
+          {
+            title: "Spa & Bien-être",
+            text: "Toutes les futures mariées ne veulent pas un week-end agité. Certaines veulent sincèrement un séjour spa : massages, saunas infrarouges, piscines thermales, bonne cuisine et couchers tôt. Ce format fonctionne parfaitement pour les groupes plus petits et soudés — quatre à six personnes plutôt que douze. Il est aussi plus prévisible sur le plan budgétaire qu'un city break, car on reste principalement au même endroit. L'enjeu : il faut l'adhésion de tout le groupe ; si la moitié s'attend à des clubs et l'autre à du silence, personne ne passe une bonne soirée.",
+            bestFor: "Futures mariées introverties, groupes axés bien-être, petits rassemblements",
+          },
+          {
+            title: "Aventure",
+            text: "Surf au Pays Basque, randonnée en Slovénie, week-end vélo en Toscane, glamping en Bretagne. Les EVJF aventure gagnent en popularité parce qu'ils créent des expériences partagées qui soudent le groupe d'une façon que la vie nocturne offre rarement. Les histoires du jour où vous êtes toutes tombées du paddleboard valent mieux qu'une nuit en boîte. L'enjeu : les séjours aventure demandent une planification physique plus approfondie et des conversations honnêtes sur les niveaux de forme. Ne réservez pas une randonnée technique en espérant que tout le monde suivra.",
+            bestFor: "Futures mariées actives, groupes qui passent déjà du temps en plein air",
+          },
+        ],
+      },
+      budgetConversation: {
+        id: "budget-conversation",
+        title: "La Conversation Budget qu'on Évite Toujours",
+        paragraphs: [
+          "C'est là que les projets d'EVJF s'effondrent. Non par mauvaise volonté — mais parce que les organisatrices reportent souvent la vraie conversation budget jusqu'à ce que les acomptes soient dus et les vols réservés, moment auquel la personne qui ne peut pas vraiment se le permettre se sent coincée et commence à en vouloir aux autres. Avoir cette conversation tôt et explicitement, avant tout engagement, est la chose la plus importante que vous puissiez faire pour la dynamique du groupe.",
+          "La future mariée ne paie traditionnellement pas sa part d'hébergement et d'activités — ce coût est réparti entre les participantes. Assurez-vous que tout le monde dans le groupe comprend cela avant que les coûts ne soient finalisés. Pour un voyage à huit où l'hébergement coûte 1 500 €, c'est 215 € par personne et non 187 €. Pas grand-chose en valeur absolue, mais autant être explicite dès le départ.",
+          "Centralisez ce que vous pouvez. Réservez l'hébergement, les transferts et les activités de groupe via une seule personne ou un outil de planification partagé pour que les flux d'argent soient clairs et que personne ne reste en avance de frais pendant des semaines. Utilisez un suivi de budget partagé pour que tout le monde voie le total courant — les groupes qui suivent les dépenses au fil de l'eau évitent la réconciliation financière inconfortable en fin de voyage.",
+        ],
+        tips: [
+          {
+            title: "Fixez un budget par personne, pas un budget total",
+            text: "Un budget total de 3 000 € semble gérable jusqu'à ce qu'on réalise que le groupe est de quinze personnes et que ça représente moins de 200 € chacune. Pensez toujours en termes de coût par personne dès le départ.",
+          },
+          {
+            title: "Distinguez l'indispensable du facultatif",
+            text: "L'hébergement et une ou deux activités clés sont non négociables. Les tenues assorties, les décorations personnalisées et les cadeaux élaborés sont optionnels. Sachez faire la différence avant de commencer à dépenser.",
+          },
+          {
+            title: "Gérez les inégalités de revenus avec tact",
+            text: "Si quelqu'un dans le groupe a un budget plus serré, laissez-la contribuer différemment — organiser un dîner, coordonner la logistique, prendre en charge des petits frais — plutôt que de la mettre dans l'embarras ou de la laisser se sentir exclue. La générosité fonctionne mieux que les conversations de subsides maladroites.",
+          },
+          {
+            title: "Utilisez un suivi de budget partagé dès le premier jour",
+            text: "Des outils comme le suivi de budget intégré de WePlanify permettent à tout le monde de voir ce qui a été payé, ce qui est dû et quel sera le coût final par personne — sans que personne n'ait à chasser des tableurs ou des demandes de remboursement en fin de voyage.",
+          },
+        ],
+      },
+      timeline: {
+        id: "timeline",
+        title: "Planning : de l'Idée à la Soirée",
+        intro:
+          "La planification d'un EVJF a tendance à s'étirer pour remplir le temps qu'on lui donne — ou à se comprimer en une course contre la montre stressante si on s'y prend trop tard. Voici un planning réaliste qui fait avancer les choses sans le chaos.",
+        steps: [
+          {
+            when: "3 mois avant",
+            tasks: [
+              "Confirmer la liste des participantes et obtenir des confirmations fermes",
+              "Avoir la vraie conversation budget avec le groupe",
+              "Se mettre d'accord sur les dates — utiliser un sondage pour trouver quand tout le monde est disponible",
+              "Choisir le type de destination selon les vraies préférences de la mariée",
+              "Réserver l'hébergement (c'est ce qui fixe tout le reste)",
+              "Créer un espace de planification partagé pour que tout le monde suive l'avancement",
+            ],
+          },
+          {
+            when: "6 semaines avant",
+            tasks: [
+              "Réserver les transports — vols, train ou transfert de groupe",
+              "Rechercher et présélectionner les activités — utiliser un sondage pour affiner",
+              "Réserver les activités incontournables qui nécessitent une réservation anticipée",
+              "Paramétrer un suivi de budget partagé et enregistrer les acomptes au fur et à mesure",
+              "Confirmer les restrictions alimentaires et besoins d'accessibilité de chaque participante",
+            ],
+          },
+          {
+            when: "2 semaines avant",
+            tasks: [
+              "Envoyer l'itinéraire final au groupe — un seul document propre, pas un fil de messages",
+              "Réserver les restaurants pour les dîners de groupe",
+              "Acheter les décorations ou objets personnalisés (écharpes, etc.) si vous en utilisez",
+              "Créer une liste de bagages partagée pour que chacune sache qui apporte quoi en commun",
+              "Relancer les paiements en attente ou les confirmations manquantes",
+            ],
+          },
+          {
+            when: "La veille",
+            tasks: [
+              "Confirmer les détails d'arrivée à l'hébergement et les partager avec le groupe",
+              "Préparer une petite trousse d'urgence : pansements, ibuprofène, chargeur, snacks",
+              "Avoir le suivi de budget ouvert et à jour",
+              "Bien dormir — vous en aurez besoin",
+            ],
+          },
+        ],
+      },
+      activities: {
+        id: "activities",
+        title: "Les Activités",
+        paragraphs: [
+          "Le meilleur programme d'EVJF a une structure claire mais beaucoup d'espace pour respirer. Les voyages trop chargés ressemblent à des sorties scolaires ; les voyages trop vides dérivent vers des disputes sur quoi faire ensuite. Visez une ou deux activités phares par jour, avec du temps libre intégré pour l'improvisation.",
+          "La règle d'or : assurez-vous qu'au moins une activité est choisie parce que la mariée l'aime vraiment, pas parce que c'est un classique de l'EVJF. Si elle déteste les ateliers cocktails mais adore la poterie, réservez la poterie. Si elle n'a jamais aimé les boîtes de nuit mais rêve d'un long dîner festif avec ses personnes préférées, donnez la priorité à ça. La version Instagram de l'EVJF n'est pas l'objectif.",
+          "Évitez le fun forcé. Les tenues assorties, les écharpes et les voiles sont bien si la mariée est partante — mais si elle a déjà mentionné que ça la mettrait mal à l'aise, ne le faites pas. Idem pour les jeux qui visent à embarrasser la mariée ou les activités qui nécessitent que tout le monde performe son bonheur. Le fun qui demande à chacune de simuler de s'amuser tombe toujours à plat.",
+        ],
+        ideas: [
+          {
+            category: "En journée",
+            items: [
+              "Location de voilier ou balade en bateau privé",
+              "Dégustation de vins ou de cocktails (session privée, pas le circuit touristique)",
+              "Matinée spa avec soins individuels",
+              "Atelier poterie, soufflage de verre ou peinture",
+              "Cours de paddle, surf ou kayak",
+              "Cours de cuisine avec un chef local",
+              "Journée chinage dans une nouvelle ville",
+            ],
+          },
+          {
+            category: "En soirée",
+            items: [
+              "Chef à domicile dans votre hébergement",
+              "Réservation dans le restaurant que la mariée voulait tester depuis longtemps",
+              "Atelier cocktails (seulement si elle le veut vraiment)",
+              "Karaoké — vraiment sous-estimé pour les groupes mixtes",
+              "Soirée à l'opéra, dans un club de jazz ou à un spectacle d'humour",
+              "Soirée casino basse mise, haute valeur divertissement",
+            ],
+          },
+          {
+            category: "Version tranquille",
+            items: [
+              "Soirée cinéma dans la villa avec le film préféré de la mariée",
+              "Soirée jeux de société avec un bon vin",
+              "Balade au coucher du soleil suivie d'un long dîner",
+              "Séance yoga ou pilates le matin",
+              "Brunch au marché local",
+            ],
+          },
+        ],
+        outro:
+          "Votez sur les activités via un sondage de groupe avant de réserver quoi que ce soit — ça évite le classique où l'organisatrice réserve quelque chose d'onéreux et deux personnes détestent ça. La fonctionnalité sondages de WePlanify prend trente secondes à configurer et donne une voix égale à chacune, sans débat de soixante messages dans le groupe.",
+      },
+    },
+
+    faq: {
+      title: "Questions Fréquentes",
+      items: [
+        {
+          q: "Combien de temps à l'avance faut-il organiser un EVJF ?",
+          a: "Pour un week-end en voyage, trois mois c'est confortable — ça laisse le temps d'aligner les agendas de tout le monde, de réserver l'hébergement avant que les prix s'envolent et d'organiser les activités sans se précipiter. Si vous planifiez quelque chose de plus ambitieux (vols internationaux, location de villa, destinations à forte demande), prévoyez quatre à cinq mois. Pour une soirée locale ou un staycation simple, six semaines suffisent généralement. La plus grosse erreur, c'est d'attendre deux mois avant le mariage, quand l'agenda de tout le monde est déjà bloqué par les essayages de robes et les autres événements du mariage.",
+        },
+        {
+          q: "Comment gérer les budgets différents dans le groupe ?",
+          a: "Abordez le sujet tôt et en privé. Demandez à chaque personne individuellement ce qu'elle est à l'aise de dépenser — pas dans un message de groupe où la pression sociale fausse les réponses. Trouvez la médiane et planifiez autour. Proposez des options supplémentaires payantes pour celles qui veulent dépenser plus, plutôt que de planifier un voyage cher en espérant que tout le monde se débrouille. Si quelqu'un ne peut vraiment pas se permettre le voyage tel qu'il est planifié, laissez-la contribuer différemment — coordonner la logistique, gérer la communication, prendre en charge un coût plus modeste — plutôt que de la mettre dans une situation inconfortable.",
+        },
+        {
+          q: "Quel est un bon budget par personne pour un EVJF ?",
+          a: "Pour un city break en Europe, comptez entre 300 et 600 € par personne pour un séjour de trois nuits incluant transport, hébergement et quelques activités en optimisant les dépenses. Les séjours plage ou villa en Europe du Sud tournent entre 400 et 800 € par personne pour un long week-end. Les destinations de bord de mer françaises (Biarritz, Côte d'Azur, Bretagne) varient beaucoup selon la saison et la taille du groupe. N'oubliez pas : la future mariée ne paie traditionnellement pas sa part, donc intégrez ce coût dans votre calcul par personne dès le départ.",
+        },
+        {
+          q: "Combien de personnes pour un EVJF ?",
+          a: "Huit à dix personnes, c'est la limite pratique supérieure pour un voyage cohésif. Au-delà, les réservations au restaurant deviennent un cauchemar, les activités nécessitent de privatiser des espaces entiers et le groupe se fragmente inévitablement. Les grands groupes impliquent aussi plus de charge logistique — plus de personnes à coordonner, plus de variables à gérer, plus de risques que quelqu'un se désiste à la dernière minute et déséquilibre le budget. Si la liste des invitées est vraiment de quinze personnes ou plus, envisagez de diviser en deux groupes avec deux séjours distincts, ou choisissez un format pensé pour les grands groupes — villa avec chef, bateau privatisé, lieu entièrement loué.",
+        },
+        {
+          q: "Et si la future mariée ne veut pas d'EVJF traditionnel ?",
+          a: "Organisez ce qu'elle veut vraiment. Il n'y a aucune règle qui dit qu'un EVJF doit inclure des écharpes, des animations paillettes ou une soirée en boîte. Si elle veut un week-end spa tranquille avec trois amies, c'est ça l'EVJF. Si elle veut un séjour rando en montagne, c'est ça l'EVJF. Le mieux c'est de lui demander directement — ou de demander à son amie ou sa sœur la plus proche. Les pires EVJF sont ceux où l'organisatrice a planifié le voyage qu'elle-même voulait faire plutôt que ce qui compte vraiment pour la mariée.",
+        },
+        {
+          q: "Comment garder tout le monde contente ?",
+          a: "Vous n'y arriverez pas complètement — et essayer vous épuisera. Visez que tout le monde passe un bon moment la plupart du temps, pas le bonheur universel à chaque instant. Intégrez de la variété dans le programme : actif et relaxant, activités de groupe et temps libre, couchers tôt et soirées plus tardives. Utilisez des sondages pour les décisions collectives pour que personne ne se sente imposé quelque chose. Fixez des attentes claires dès le départ sur le budget, le niveau de formalité et ce qui est ou non prévu. Et acceptez que certaines personnes soient plus difficiles à contenter que d'autres — c'est vrai de tous les voyages de groupe, pas seulement des EVJF.",
+        },
+      ],
+    },
+
+    cta: {
+      title: "Prêt à Organiser l'EVJF Parfait ?",
+      text: "WePlanify réunit tout votre groupe au même endroit — sondages de destination, itinéraire partagé, suivi de budget et listes de bagages. Arrêtez de gérer le chaos dans un groupe WhatsApp et commencez vraiment à planifier ensemble.",
+      button: "Organiser l'EVJF",
+    },
+
+    discoverMore: "Découvrir aussi",
+    readMore: "En savoir plus",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// JSON-LD Schemas
+// ---------------------------------------------------------------------------
+
+function BreadcrumbJsonLd({ locale }: { locale: string }) {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: locale === "fr" ? "Accueil" : "Home",
+        item: `${SITE_URL}/${locale}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: `${SITE_URL}/${locale}/blog`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name:
+          locale === "fr"
+            ? "Organiser un EVJF"
+            : "How to Plan a Bachelorette Party",
+        item: `${SITE_URL}/${locale}${locale === "fr" ? PATHNAME_FR : PATHNAME_EN}`,
+      },
+    ],
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
+function FaqJsonLd({ locale }: { locale: string }) {
+  const c = locale === "fr" ? content.fr : content.en;
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: c.faq.items.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.a,
+      },
+    })),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
+function ArticleJsonLd({ locale }: { locale: string }) {
+  const c = locale === "fr" ? content.fr : content.en;
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: c.h1,
+    description: locale === "fr" ? meta.fr.description : meta.en.description,
+    author: {
+      "@type": "Organization",
+      name: "WePlanify",
+      url: SITE_URL,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "WePlanify",
+      url: SITE_URL,
+    },
+    datePublished: "2026-04-15",
+    dateModified: "2026-04-15",
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `${SITE_URL}/${locale}${locale === "fr" ? PATHNAME_FR : PATHNAME_EN}`,
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page Component
+// ---------------------------------------------------------------------------
+
+export default async function OrganiserEvjfPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const c = locale === "fr" ? content.fr : content.en;
+
+  const [navData, navigationData, footerData]: [
+    NavType,
+    Navigation | null,
+    FooterType | null,
+  ] = await Promise.all([
+    sanityFetch<NavType>({
+      query: navQuery,
+      params: { locale },
+      tags: ["nav"],
+    }),
+    sanityFetch<Navigation>({
+      query: navigationQuery,
+      params: { locale },
+      tags: ["navigation"],
+    }),
+    sanityFetch<FooterType>({
+      query: footerQuery,
+      params: { locale },
+      tags: ["footer"],
+    }),
+  ]);
+
+  return (
+    <>
+      <AuthorJsonLd />
+      <BreadcrumbJsonLd locale={locale} />
+      <FaqJsonLd locale={locale} />
+      <ArticleJsonLd locale={locale} />
+
+      <Nav navData={navData} navigationData={navigationData} />
+
+      <main className="min-h-screen bg-[#FFFBF5]">
+        {/* Hero */}
+        <header className="pt-[120px] lg:pt-[140px] pb-12 lg:pb-16 px-4 lg:px-8">
+          <div className="max-w-3xl mx-auto">
+            <div className="hidden lg:block mb-6">
+              <Breadcrumb
+                items={[
+                  {
+                    label: locale === "fr" ? "Accueil" : "Home",
+                    href: `/${locale}`,
+                  },
+                  {
+                    label: "Blog",
+                    href: `/${locale}/blog`,
+                  },
+                  {
+                    label:
+                      locale === "fr"
+                        ? "Organiser un EVJF"
+                        : "How to Plan a Bachelorette Party",
+                  },
+                ]}
+              />
+            </div>
+            <span className="inline-block bg-[#EEF899] text-[#001E13] text-sm font-karla font-semibold px-4 py-1.5 rounded-full mb-6">
+              {c.heroTag}
+            </span>
+            <h1 className="text-[#001E13] text-3xl lg:text-[44px] font-londrina-solid leading-tight mb-4">
+              {c.h1}
+            </h1>
+            <p className="text-[#001E13]/60 text-sm font-karla mb-6">
+              {c.readTime}
+            </p>
+            <p className="text-[#001E13]/80 text-base lg:text-lg font-karla leading-relaxed">
+              {c.intro}
+            </p>
+          </div>
+        </header>
+
+        {/* Author */}
+        <div className="max-w-3xl mx-auto px-4 lg:px-8">
+          <AuthorBio
+            locale={locale}
+            publishedDate="2026-04-15"
+            modifiedDate="2026-04-15"
+          />
+        </div>
+
+        {/* Table of Contents */}
+        <nav aria-label={c.tocTitle} className="py-10 lg:py-12 px-4 lg:px-8">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="text-[#001E13] text-xl lg:text-2xl font-londrina-solid mb-5">
+              {c.tocTitle}
+            </h2>
+            <ol className="space-y-2">
+              {c.toc.map((item) => (
+                <li key={item.id}>
+                  <a
+                    href={`#${item.id}`}
+                    className="text-[#001E13]/70 hover:text-[#F6391A] font-karla text-sm lg:text-base transition-colors"
+                  >
+                    {item.label}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </nav>
+
+        {/* Divider */}
+        <div className="max-w-3xl mx-auto px-4 lg:px-8">
+          <hr className="border-[#001E13]/10" />
+        </div>
+
+        {/* Article body */}
+        <article className="py-10 lg:py-14 px-4 lg:px-8">
+          <div className="max-w-3xl mx-auto space-y-16 lg:space-y-20">
+
+            {/* Section 1: Why Hard */}
+            <section id={c.sections.whyHard.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.whyHard.title}
+              </h2>
+              <div className="space-y-4">
+                {c.sections.whyHard.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+            </section>
+
+            {/* Section 2: Four Questions */}
+            <section id={c.sections.fourQuestions.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.fourQuestions.title}
+              </h2>
+              <p className="text-[#001E13]/80 text-base font-karla leading-relaxed mb-8">
+                {c.sections.fourQuestions.intro}
+              </p>
+              <div className="grid gap-4">
+                {c.sections.fourQuestions.questions.map((item, i) => (
+                  <div
+                    key={i}
+                    className="bg-white border border-[#001E13]/10 rounded-2xl p-6"
+                  >
+                    <h3 className="text-[#001E13] text-lg font-londrina-solid mb-2">
+                      {item.title}
+                    </h3>
+                    <p className="text-[#001E13]/70 text-sm lg:text-base font-karla leading-relaxed">
+                      {item.text}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-6 text-[#001E13]/70 text-sm font-karla leading-relaxed">
+                {locale === "fr"
+                  ? "Besoin d'un sondage pour aligner les dates ou les préférences de destination ? "
+                  : "Need a poll to align on dates or destination preferences? "}
+                <Link
+                  href={`/${locale}/features/polls`}
+                  className="text-[#F6391A] font-semibold hover:underline"
+                >
+                  {locale === "fr"
+                    ? "La fonction sondages de WePlanify"
+                    : "WePlanify's polls feature"}
+                </Link>
+                {locale === "fr"
+                  ? " règle ça en trente secondes."
+                  : " settles it in thirty seconds."}
+              </p>
+            </section>
+
+            {/* Section 3: Destination Types */}
+            <section id={c.sections.destinationTypes.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.destinationTypes.title}
+              </h2>
+              <p className="text-[#001E13]/80 text-base font-karla leading-relaxed mb-8">
+                {c.sections.destinationTypes.intro}
+              </p>
+              <div className="space-y-6">
+                {c.sections.destinationTypes.types.map((type, i) => (
+                  <div
+                    key={i}
+                    className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8"
+                  >
+                    <h3 className="text-[#001E13] text-xl lg:text-2xl font-londrina-solid mb-3">
+                      {type.title}
+                    </h3>
+                    <p className="text-[#001E13]/80 text-base font-karla leading-relaxed mb-4">
+                      {type.text}
+                    </p>
+                    <p className="text-[#F6391A] font-karla font-bold text-sm">
+                      {locale === "fr" ? "Idéal pour : " : "Best for: "}
+                      <span className="text-[#001E13]/70 font-normal">
+                        {type.bestFor}
+                      </span>
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-6 text-[#001E13]/70 text-sm font-karla leading-relaxed">
+                {locale === "fr"
+                  ? "Vous organisez un EVJF ? "
+                  : "Planning a bachelorette trip? "}
+                <Link
+                  href={`/${locale}/bachelorette-trip`}
+                  className="text-[#F6391A] font-semibold hover:underline"
+                >
+                  {locale === "fr"
+                    ? "Découvrez comment WePlanify simplifie l'EVJF de bout en bout"
+                    : "See how WePlanify simplifies the whole bachelorette from start to finish"}
+                </Link>
+                {locale === "fr" ? "." : "."}
+              </p>
+            </section>
+
+            {/* Section 4: Budget */}
+            <section id={c.sections.budgetConversation.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.budgetConversation.title}
+              </h2>
+              <div className="space-y-4 mb-8">
+                {c.sections.budgetConversation.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+              <div className="grid gap-4">
+                {c.sections.budgetConversation.tips.map((tip, i) => (
+                  <div
+                    key={i}
+                    className="bg-white border border-[#001E13]/10 rounded-2xl p-6"
+                  >
+                    <h3 className="text-[#001E13] text-lg font-londrina-solid mb-2">
+                      {tip.title}
+                    </h3>
+                    <p className="text-[#001E13]/70 text-sm lg:text-base font-karla leading-relaxed">
+                      {tip.text}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-6 text-[#001E13]/70 text-sm font-karla leading-relaxed">
+                {locale === "fr"
+                  ? "Le suivi de budget partagé de WePlanify est disponible ici : "
+                  : "WePlanify's shared budget tracker is available here: "}
+                <Link
+                  href={`/${locale}/features/budget`}
+                  className="text-[#F6391A] font-semibold hover:underline"
+                >
+                  {locale === "fr"
+                    ? "Budget partagé"
+                    : "Shared budget"}
+                </Link>
+                {locale === "fr"
+                  ? " — suivi en temps réel, calcul automatique des remboursements."
+                  : " — real-time tracking, automatic reimbursement calculation."}
+              </p>
+            </section>
+
+            {/* Section 5: Timeline */}
+            <section id={c.sections.timeline.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.timeline.title}
+              </h2>
+              <p className="text-[#001E13]/80 text-base font-karla leading-relaxed mb-8">
+                {c.sections.timeline.intro}
+              </p>
+              <div className="space-y-6">
+                {c.sections.timeline.steps.map((step, i) => (
+                  <div
+                    key={i}
+                    className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8"
+                  >
+                    <h3 className="text-[#001E13] text-xl font-londrina-solid mb-4">
+                      {step.when}
+                    </h3>
+                    <ul className="space-y-2">
+                      {step.tasks.map((task, j) => (
+                        <li
+                          key={j}
+                          className="text-[#001E13]/70 text-sm lg:text-base font-karla flex items-start gap-3"
+                        >
+                          <span className="text-[#F6391A] mt-0.5 flex-shrink-0 font-bold">
+                            ·
+                          </span>
+                          {task}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* Section 6: Activities */}
+            <section id={c.sections.activities.id}>
+              <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid leading-tight mb-6">
+                {c.sections.activities.title}
+              </h2>
+              <div className="space-y-4 mb-8">
+                {c.sections.activities.paragraphs.map((p, i) => (
+                  <p
+                    key={i}
+                    className="text-[#001E13]/80 text-base font-karla leading-relaxed"
+                  >
+                    {p}
+                  </p>
+                ))}
+              </div>
+              <div className="grid md:grid-cols-3 gap-6 mb-8">
+                {c.sections.activities.ideas.map((category, i) => (
+                  <div
+                    key={i}
+                    className="bg-white border border-[#001E13]/10 rounded-2xl p-6"
+                  >
+                    <h3 className="text-[#001E13] text-lg font-londrina-solid mb-4">
+                      {category.category}
+                    </h3>
+                    <ul className="space-y-2">
+                      {category.items.map((item, j) => (
+                        <li
+                          key={j}
+                          className="text-[#001E13]/70 text-sm font-karla flex items-start gap-2"
+                        >
+                          <span className="text-[#F6391A] mt-0.5 flex-shrink-0">
+                            +
+                          </span>
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+              <p className="text-[#001E13]/80 text-base font-karla leading-relaxed">
+                {c.sections.activities.outro}
+              </p>
+              <p className="mt-4 text-[#001E13]/70 text-sm font-karla leading-relaxed">
+                {locale === "fr"
+                  ? "Coordonnez aussi les bagages du groupe avec "
+                  : "Coordinate group packing too with "}
+                <Link
+                  href={`/${locale}/features/packing`}
+                  className="text-[#F6391A] font-semibold hover:underline"
+                >
+                  {locale === "fr"
+                    ? "les listes de bagages partagées de WePlanify"
+                    : "WePlanify's shared packing lists"}
+                </Link>
+                {locale === "fr"
+                  ? " — fini les doublons et les oublis."
+                  : " — no more duplicates or forgotten items."}
+              </p>
+            </section>
+          </div>
+        </article>
+
+        {/* Divider */}
+        <div className="max-w-3xl mx-auto px-4 lg:px-8">
+          <hr className="border-[#001E13]/10" />
+        </div>
+
+        {/* FAQ */}
+        <section id="faq" className="py-12 lg:py-16 px-4 lg:px-8 bg-white">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid mb-8">
+              {c.faq.title}
+            </h2>
+            <div className="space-y-6">
+              {c.faq.items.map((item, i) => (
+                <details
+                  key={i}
+                  className="group border-b border-[#001E13]/10 pb-5"
+                >
+                  <summary className="flex items-start justify-between cursor-pointer list-none font-karla font-semibold text-[#001E13] text-base lg:text-lg">
+                    <span className="pr-4">{item.q}</span>
+                    <span className="text-[#F6391A] text-xl leading-none mt-0.5 group-open:rotate-45 transition-transform">
+                      +
+                    </span>
+                  </summary>
+                  <p className="mt-3 text-[#001E13]/70 text-sm lg:text-base font-karla leading-relaxed">
+                    {item.a}
+                  </p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Discover More */}
+        <section className="py-16 lg:py-20 px-4 lg:px-8 bg-[#FFFBF5]">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="text-[#001E13] text-2xl lg:text-3xl font-londrina-solid text-center mb-10">
+              {c.discoverMore}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <Link href={`/${locale}/bachelorette-trip`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 hover:shadow-lg transition-shadow duration-300 h-full">
+                  <h3 className="text-lg font-londrina-solid text-[#001E13] mb-2">
+                    {locale === "fr"
+                      ? "Planificateur EVJF"
+                      : "Bachelorette Trip Planner"}
+                  </h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">
+                    {locale === "fr"
+                      ? "Tout ce qu'il faut pour organiser votre EVJF avec WePlanify : sondages, budget partagé et itinéraire collaboratif."
+                      : "Everything you need to plan your bachelorette trip with WePlanify: polls, shared budget, and collaborative itinerary."}
+                  </p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">
+                    {c.readMore} →
+                  </span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/trip-with-friends`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 hover:shadow-lg transition-shadow duration-300 h-full">
+                  <h3 className="text-lg font-londrina-solid text-[#001E13] mb-2">
+                    {locale === "fr"
+                      ? "Voyage entre Amis"
+                      : "Trip with Friends"}
+                  </h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">
+                    {locale === "fr"
+                      ? "Organisez un voyage de groupe entre amis facilement avec WePlanify."
+                      : "Plan a group trip with friends effortlessly using WePlanify."}
+                  </p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">
+                    {c.readMore} →
+                  </span>
+                </div>
+              </Link>
+              <Link
+                href={`/${locale}/guides/plan-group-trip`}
+                className="group"
+              >
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 hover:shadow-lg transition-shadow duration-300 h-full">
+                  <h3 className="text-lg font-londrina-solid text-[#001E13] mb-2">
+                    {locale === "fr"
+                      ? "Guide Voyage de Groupe"
+                      : "Group Trip Planning Guide"}
+                  </h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">
+                    {locale === "fr"
+                      ? "Comment organiser un voyage de groupe de A à Z, étape par étape."
+                      : "How to plan a group trip from start to finish, step by step."}
+                  </p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">
+                    {c.readMore} →
+                  </span>
+                </div>
+              </Link>
+              <Link
+                href={`/${locale}/blog/meilleures-applications-voyage-groupe`}
+                className="group"
+              >
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 hover:shadow-lg transition-shadow duration-300 h-full">
+                  <h3 className="text-lg font-londrina-solid text-[#001E13] mb-2">
+                    {locale === "fr"
+                      ? "Meilleures Applis Voyage de Groupe"
+                      : "Best Group Trip Planner Apps"}
+                  </h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">
+                    {locale === "fr"
+                      ? "Comparatif honnête des meilleures applications pour voyager en groupe en 2026."
+                      : "An honest comparison of the best apps for planning a group trip in 2026."}
+                  </p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">
+                    {c.readMore} →
+                  </span>
+                </div>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="py-16 lg:py-20 px-4 lg:px-8">
+          <div className="max-w-3xl mx-auto text-center">
+            <div className="bg-[#F6391A] rounded-3xl p-8 lg:p-14">
+              <h2 className="text-[#FFFBF5] text-2xl lg:text-4xl font-londrina-solid mb-4">
+                {c.cta.title}
+              </h2>
+              <p className="text-[#FFFBF5]/90 text-sm lg:text-base font-karla leading-relaxed mb-8 max-w-xl mx-auto">
+                {c.cta.text}
+              </p>
+              <Link
+                href="https://app.weplanify.com"
+                className="inline-block bg-[#001E13] hover:bg-[#001E13]/85 text-[#FFFBF5] font-karla font-bold text-sm lg:text-base px-8 py-3.5 rounded-full transition-colors"
+              >
+                {c.cta.button}
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer footerData={footerData} />
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -55,7 +55,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
 
     // Guide & hardcoded blog pages for each locale
-    const guidePages = ["guides/plan-group-trip", "blog/meilleures-applications-voyage-groupe"];
+    const guidePages = [
+      "guides/plan-group-trip",
+      "blog/meilleures-applications-voyage-groupe",
+      "blog/organiser-evjf",
+      "blog/group-trip-budget",
+    ];
     for (const locale of locales) {
       for (const page of guidePages) {
         entries.push({


### PR DESCRIPTION
- /blog/organiser-evjf (FR: "Comment Organiser un EVJF") — targets "organiser evjf", "idees evjf"; zero-competition FR keyword; 1236 lines, bilingual EN/FR
- /blog/group-trip-budget (EN: "Group Trip Budget: How to Split Costs Without Drama") targets "group trip budget", "split travel expenses"; 962 lines, bilingual EN/FR
- sitemap.ts: add both new static blog pages for EN and FR locales
- Both articles: BreadcrumbList + Article + FAQPage JSON-LD, AuthorBio, TOC, internal links to features/budget, features/polls, bachelorette-trip, trip-with-friends