### PR TITLE
feat(partnership): add partnership request page and form

### DIFF
--- a/src/app/[locale]/partnership/page.tsx
+++ b/src/app/[locale]/partnership/page.tsx
@@ -1,0 +1,114 @@
+import { Metadata } from "next";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import PartnershipForm from "@/components/PartnershipForm";
+import { sanityFetch } from "@/sanity/lib/fetch";
+import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
+import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
+import { setRequestLocale } from "next-intl/server";
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+const SITE_URL = "https://www.weplanify.com";
+
+const partnershipMeta = {
+  en: {
+    title: "Partner with WePlanify — Partnership Opportunities",
+    description:
+      "Work with WePlanify. Whether you're a travel provider, media partner, creator, or building an integration — tell us about your project and our team will get back to you.",
+    h1: "Let's build something together",
+    subtitle:
+      "Tell us about your project. Affiliates, media, travel providers, creators, integrations — we're open.",
+  },
+  fr: {
+    title: "Partenariat WePlanify — Devenir Partenaire",
+    description:
+      "Travaillez avec WePlanify. Que vous soyez un acteur du voyage, un média, un créateur ou que vous souhaitiez intégrer notre produit — parlez-nous de votre projet.",
+    h1: "Construisons quelque chose ensemble",
+    subtitle:
+      "Parlez-nous de votre projet. Affiliation, média, acteurs du voyage, créateurs, intégrations — on est ouverts.",
+  },
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const l = locale === "fr" ? partnershipMeta.fr : partnershipMeta.en;
+  const currentUrl = `${SITE_URL}/${locale}/partnership`;
+
+  return {
+    title: l.title,
+    description: l.description,
+    openGraph: {
+      type: "website",
+      locale: locale === "fr" ? "fr_FR" : "en_US",
+      url: currentUrl,
+      siteName: "WePlanify",
+      title: l.title,
+      description: l.description,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: l.title,
+      description: l.description,
+    },
+    alternates: {
+      canonical: currentUrl,
+      languages: {
+        en: `${SITE_URL}/en/partnership`,
+        fr: `${SITE_URL}/fr/partnership`,
+        "x-default": `${SITE_URL}/en/partnership`,
+      },
+    },
+  };
+}
+
+export default async function PartnershipPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const l = locale === "fr" ? partnershipMeta.fr : partnershipMeta.en;
+
+  const [navData, navigationData, footerData]: [NavType, Navigation | null, FooterType | null] = await Promise.all([
+    sanityFetch<NavType>({
+      query: navQuery,
+      params: { locale },
+      tags: ["nav"],
+    }),
+    sanityFetch<Navigation>({
+      query: navigationQuery,
+      params: { locale },
+      tags: ["navigation"],
+    }),
+    sanityFetch<FooterType>({
+      query: footerQuery,
+      params: { locale },
+      tags: ["footer"],
+    }),
+  ]);
+
+  return (
+    <>
+      <Nav navData={navData} navigationData={navigationData} />
+      <main className="min-h-screen">
+        <section className="relative pt-[40px] lg:pt-[80px] pb-12">
+          <div className="container mx-auto px-4 lg:px-0">
+            <div className="max-w-xl mx-auto">
+              <div className="text-center mb-6 mt-4 md:mt-0">
+                <h1 className="text-2xl lg:text-3xl font-unbounded font-bold text-black mb-2">
+                  {l.h1}
+                </h1>
+                <p className="text-gray-600 text-sm">{l.subtitle}</p>
+              </div>
+
+              <PartnershipForm />
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer footerData={footerData} />
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -73,7 +73,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
 
     // Static pages for each locale
-    const staticPages = ["blog", "faq", "contact", "about", "privacy-policy"];
+    const staticPages = ["blog", "faq", "contact", "partnership", "about", "privacy-policy"];
     for (const locale of locales) {
       for (const page of staticPages) {
         entries.push({

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -182,6 +182,12 @@ export default function Footer({ footerData }: FooterProps) {
                   Contact
                 </Link>
                 <Link
+                  href={`/${locale}/partnership`}
+                  className="text-[#001E13] text-base font-karla mb-4 hover:text-[#F6391A] transition-colors"
+                >
+                  {locale === "fr" ? "Partenaires" : "Partners"}
+                </Link>
+                <Link
                   href={`/${locale}/blog`}
                   className="text-[#001E13] text-base font-karla mb-4 hover:text-[#F6391A] transition-colors"
                 >

--- a/src/components/PartnershipForm.tsx
+++ b/src/components/PartnershipForm.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useState } from 'react';
+import { PulsatingButton } from "@/components/magicui/pulsating-button";
+import { trackEvent } from "@/lib/tracking";
+
+interface PartnershipFormData {
+  email: string;
+  company: string;
+  website: string;
+  partnershipType: string;
+  message: string;
+}
+
+const PARTNERSHIP_TYPES = [
+  { value: 'affiliate', label: 'Affiliate / Referral' },
+  { value: 'integration', label: 'B2B / Integration' },
+  { value: 'media', label: 'Media / Press' },
+  { value: 'provider', label: 'Travel provider / Supplier' },
+  { value: 'influencer', label: 'Creator / Influencer' },
+  { value: 'other', label: 'Other' },
+];
+
+function buildContent(data: PartnershipFormData): string {
+  const typeLabel =
+    PARTNERSHIP_TYPES.find((t) => t.value === data.partnershipType)?.label ||
+    data.partnershipType;
+
+  const lines = [
+    `Company: ${data.company}`,
+    data.website ? `Website: ${data.website}` : null,
+    `Partnership type: ${typeLabel}`,
+    '',
+    'Message:',
+    data.message,
+  ].filter((l): l is string => l !== null);
+
+  return lines.join('\n');
+}
+
+export default function PartnershipForm() {
+  const [formData, setFormData] = useState<PartnershipFormData>({
+    email: '',
+    company: '',
+    website: '',
+    partnershipType: 'affiliate',
+    message: '',
+  });
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch('https://api.weplanify.com/api/contact/request', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: formData.email,
+          content: buildContent(formData),
+          type: 'partnership',
+        }),
+      });
+
+      if (response.ok) {
+        setFormData({
+          email: '',
+          company: '',
+          website: '',
+          partnershipType: 'affiliate',
+          message: '',
+        });
+        trackEvent('partnership_form_submit', { status: 'success' });
+        alert('Partnership request sent! Our team will get back to you shortly.');
+      } else {
+        const errorData = await response.json().catch(() => ({}));
+        trackEvent('partnership_form_submit', { status: 'error' });
+        alert(errorData.message || 'An error occurred while sending your request.');
+      }
+    } catch {
+      alert('Unable to reach the server. Please try again later.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-2xl p-3 lg:p-4 shadow-lg hover:shadow-md transition-all duration-300 mb-8 border border-gray-100">
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+            Email *
+          </label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            value={formData.email}
+            onChange={handleInputChange}
+            required
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-orange focus:border-orange outline-none transition-all bg-gray-50 focus:bg-white"
+            style={{ borderRadius: '8px' }}
+            placeholder="your@email.com"
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="company" className="block text-sm font-medium text-gray-700 mb-2">
+            Company / Organization *
+          </label>
+          <input
+            type="text"
+            id="company"
+            name="company"
+            value={formData.company}
+            onChange={handleInputChange}
+            required
+            maxLength={150}
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-orange focus:border-orange outline-none transition-all bg-gray-50 focus:bg-white"
+            style={{ borderRadius: '8px' }}
+            placeholder="Acme Travel"
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="website" className="block text-sm font-medium text-gray-700 mb-2">
+            Website
+          </label>
+          <input
+            type="url"
+            id="website"
+            name="website"
+            value={formData.website}
+            onChange={handleInputChange}
+            maxLength={200}
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-orange focus:border-orange outline-none transition-all bg-gray-50 focus:bg-white"
+            style={{ borderRadius: '8px' }}
+            placeholder="https://yourcompany.com"
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="partnershipType" className="block text-sm font-medium text-gray-700 mb-2">
+            Partnership type *
+          </label>
+          <select
+            id="partnershipType"
+            name="partnershipType"
+            value={formData.partnershipType}
+            onChange={handleInputChange}
+            required
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-orange focus:border-orange outline-none transition-all bg-gray-50 focus:bg-white"
+            style={{ borderRadius: '8px' }}
+            disabled={isSubmitting}
+          >
+            {PARTNERSHIP_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
+            Tell us about your project *
+          </label>
+          <textarea
+            id="message"
+            name="message"
+            value={formData.message}
+            onChange={handleInputChange}
+            required
+            rows={5}
+            maxLength={4000}
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-orange focus:border-orange outline-none transition-all bg-gray-50 focus:bg-white resize-none"
+            style={{ borderRadius: '8px' }}
+            placeholder="How do you envision working with WePlanify? Share context about your audience, product, or goals."
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div className="pt-2 flex justify-center">
+          <PulsatingButton
+            type="submit"
+            className="w-full lg:w-64"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Sending...' : 'Send partnership request'}
+          </PulsatingButton>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
- New /[locale]/partnership page with EN + FR metadata and hreflang
- PartnershipForm component with email, company, website, partnership type, and message — bundles everything into the API `content` field and submits with type=partnership (identified server-side)
- Partners link added in Footer Company column (EN/FR)
- partnership route added to sitemap