### PR TITLE
fix(landing): navbar gap + visible Partners footer link

### DIFF
--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -86,7 +86,7 @@ export default async function ContactPage({ params }: Props) {
       <Nav navData={navData} navigationData={navigationData} />
       <main className="min-h-screen">
         {/* Contact Form Section */}
-        <section className="relative pt-[40px] lg:pt-[80px] pb-12">
+        <section className="relative pt-[128px] lg:pt-[180px] pb-12">
           <div className="container mx-auto px-4 lg:px-0">
             <div className="max-w-xl mx-auto">
               {/* Title and Description */}

--- a/src/app/[locale]/partnership/page.tsx
+++ b/src/app/[locale]/partnership/page.tsx
@@ -92,7 +92,7 @@ export default async function PartnershipPage({ params }: Props) {
     <>
       <Nav navData={navData} navigationData={navigationData} />
       <main className="min-h-screen">
-        <section className="relative pt-[40px] lg:pt-[80px] pb-12">
+        <section className="relative pt-[128px] lg:pt-[180px] pb-12">
           <div className="container mx-auto px-4 lg:px-0">
             <div className="max-w-xl mx-auto">
               <div className="text-center mb-6 mt-4 md:mt-0">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -128,24 +128,37 @@ export default function Footer({ footerData }: FooterProps) {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-16 lg:mb-20">
           {/* Footer Columns */}
           <div className="lg:col-span-2 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-6">
-            {footerData?.footerColumns?.map((column, index) => (
-              <div key={index} className="flex flex-col">
-                <h3 className="text-[#001E13] text-base font-karla font-bold mb-6">
-                  {column.title}
-                </h3>
-                {column.links?.map((link, linkIndex) => (
-                  <a
-                    key={linkIndex}
-                    href={link.url || "#"}
-                    className="text-[#001E13] text-base font-karla mb-4 hover:text-[#F6391A] transition-colors"
-                    target={link.isExternal ? "_blank" : undefined}
-                    rel={link.isExternal ? "noopener noreferrer" : undefined}
-                  >
-                    {link.label}
-                  </a>
-                ))}
-              </div>
-            ))}
+            {footerData?.footerColumns?.map((column, index) => {
+              const isCompanyColumn =
+                column.title?.toLowerCase() === "company" ||
+                column.title?.toLowerCase() === "entreprise";
+              return (
+                <div key={index} className="flex flex-col">
+                  <h3 className="text-[#001E13] text-base font-karla font-bold mb-6">
+                    {column.title}
+                  </h3>
+                  {column.links?.map((link, linkIndex) => (
+                    <a
+                      key={linkIndex}
+                      href={link.url || "#"}
+                      className="text-[#001E13] text-base font-karla mb-4 hover:text-[#F6391A] transition-colors"
+                      target={link.isExternal ? "_blank" : undefined}
+                      rel={link.isExternal ? "noopener noreferrer" : undefined}
+                    >
+                      {link.label}
+                    </a>
+                  ))}
+                  {isCompanyColumn && (
+                    <Link
+                      href={`/${locale}/partnership`}
+                      className="text-[#001E13] text-base font-karla mb-4 hover:text-[#F6391A] transition-colors"
+                    >
+                      {locale === "fr" ? "Partenaires" : "Partners"}
+                    </Link>
+                  )}
+                </div>
+              );
+            })}
             {/* Resources column for SEO pages */}
             <div className="flex flex-col">
               <h3 className="text-[#001E13] text-base font-karla font-bold mb-6">


### PR DESCRIPTION
## Summary

Two small fixes noticed after the partnership page went live:

1. **Navbar gap** — `/contact` and `/partnership` rendered their H1 flush against the fixed navbar (`pt-[40px] lg:pt-[80px]` is too small vs the ~86px nav height). Aligned with the pattern used on `/faq` and `/about` at `pt-[128px] lg:pt-[180px]`.
2. **Partners footer link invisible in production** — the link was only in the *fallback* Company column, which is hidden when Sanity already provides a Company / Entreprise column (which it does in prod). Now the Partners link is also injected into any Sanity-provided Company column, while the fallback keeps its existing entry.

## Test plan

- [ ] Open `/en/contact`, `/fr/contact`, `/en/partnership`, `/fr/partnership` → title has visible space below the navbar on mobile and desktop
- [ ] Footer shows "Partners / Partenaires" link on all public pages, regardless of Sanity footer configuration
- [ ] Partners link navigates to `/[locale]/partnership`

🤖 Generated with [Claude Code](https://claude.com/claude-code)