### PR TITLE
landing: replace shared CTA buttons with inline pitch teaser

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -225,7 +225,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         {/* Articles similaires */}
         <RelatedArticles articles={article.relatedArticles || []} />
 
-        <CTASection footer={footerData} ctaData={ctaData} />
+        <CTASection footer={footerData} ctaData={ctaData} locale={locale} />
 
       </main>
       <Footer footerData={footerData} />

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -281,7 +281,7 @@ export default async function HomePage({ params }: Props) {
       {featureImageSection && <FadeIn><FeatureImageSection data={featureImageSection} /></FadeIn>}
 
       {/* CTA Banner */}
-      {ctaBanner && <FadeIn><CTABanner data={ctaBanner} /></FadeIn>}
+      {ctaBanner && <FadeIn><CTABanner data={ctaBanner} locale={locale} /></FadeIn>}
 
       {/* FAQ Support */}
       {faq && (
@@ -293,7 +293,7 @@ export default async function HomePage({ params }: Props) {
       )}
 
       {/* Ready Banner */}
-      {readyBanner && <FadeIn><ReadyBanner data={readyBanner} /></FadeIn>}
+      {readyBanner && <FadeIn><ReadyBanner data={readyBanner} locale={locale} /></FadeIn>}
 
       {/* Footer */}
       <Footer footerData={footerData} />

--- a/src/components/CTABanner.tsx
+++ b/src/components/CTABanner.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { PulsatingButton } from "@/components/magicui/pulsating-button";
 import Image from "next/image";
-import Link from "next/link";
-import { trackEvent } from "@/lib/tracking";
+import InlinePitch from "@/components/InlinePitch";
 
 interface CTABannerProps {
   data: {
@@ -16,9 +14,10 @@ interface CTABannerProps {
     buttonUrl: string;
     backgroundImage: string;
   };
+  locale?: string;
 }
 
-export default function CTABanner({ data }: CTABannerProps) {
+export default function CTABanner({ data, locale }: CTABannerProps) {
   if (!data) return null;
 
   return (
@@ -63,13 +62,9 @@ export default function CTABanner({ data }: CTABannerProps) {
                 </p>
               </div>
 
-              {/* Right side - CTA Button with social proof */}
+              {/* Right side - Inline pitch with social proof */}
               <div className="flex-shrink-0 flex flex-col items-start lg:items-end gap-2">
-                <Link href={data.buttonUrl || "https://app.weplanify.com/register"} onClick={() => trackEvent("cta_click", { location: "cta_banner", label: data.buttonText })}>
-                  <PulsatingButton className="font-karla font-bold">
-                    {data.buttonText}
-                  </PulsatingButton>
-                </Link>
+                <InlinePitch locale={locale} variant="light" location="cta_banner" />
                 <p className="text-[#FFFBF5]/80 text-xs lg:text-sm font-karla">
                   50k+ trips planned. Free forever.
                 </p>

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -1,15 +1,14 @@
 import Image from "next/image";
-import Link from "next/link";
-import { trackEvent } from "@/lib/tracking";
 import { CtaType } from "@/sanity/lib/type";
-import { PulsatingButtonWhite } from "@/components/magicui/pulsating-button-white-black";
+import InlinePitch from "@/components/InlinePitch";
 
 interface CTASectionProps {
   footer?: unknown; // Deprecated - kept for compatibility but not used
   ctaData: CtaType;
+  locale?: string;
 }
 
-export default function CTASection({ ctaData }: CTASectionProps) {
+export default function CTASection({ ctaData, locale }: CTASectionProps) {
   // Extract parts from ctaData
   const title = [
     ctaData.titlePart1,
@@ -52,11 +51,7 @@ export default function CTASection({ ctaData }: CTASectionProps) {
           {ctaData.description}
         </div>
         <div className="mt-[34px] flex justify-center">
-          <Link href={ctaData.buttonUrl || 'https://app.weplanify.com/register'} rel="nofollow" onClick={() => trackEvent("cta_click", { location: "cta_section", label: ctaData.buttonText })}>
-            <PulsatingButtonWhite>
-              {ctaData.buttonText}
-            </PulsatingButtonWhite>
-          </Link>
+          <InlinePitch locale={locale} variant="light" location="cta_section" />
         </div>
       </div>
     </section>

--- a/src/components/InlinePitch.tsx
+++ b/src/components/InlinePitch.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { ArrowRight, Loader2, MapPin, RotateCcw, Sparkles } from "lucide-react";
+import { trackEvent } from "@/lib/tracking";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.weplanify.com";
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://app.weplanify.com";
+
+type Lang = "en" | "fr";
+
+type UnsplashPhoto = {
+  urls: { thumb: string | null; small: string | null; regular: string | null; full?: string | null };
+};
+
+type TripPreview = {
+  destination: string;
+  country: string | null;
+  tagline: string;
+  cover: UnsplashPhoto | null;
+  highlights?: { title: string; description: string }[];
+};
+
+type Variant = "light" | "dark";
+
+interface Props {
+  locale?: string;
+  /** "light" = light card on dark bg (CTABanner-like). "dark" = white card on light bg (CTASection-like). */
+  variant?: Variant;
+  /** Where this teaser lives, sent as a tracking dimension. */
+  location: string;
+}
+
+const COPY: Record<Lang, {
+  placeholder: string;
+  submit: string;
+  submitting: string;
+  cta: string;
+  retry: string;
+  errorGeneric: string;
+  errorRateLimit: string;
+  overline: string;
+  caption: string;
+}> = {
+  en: {
+    placeholder: "I want to chill on a Mexican beach with ruins nearby...",
+    submit: "Plan it",
+    submitting: "Crafting…",
+    cta: "Plan this trip",
+    retry: "Another pitch",
+    errorGeneric: "Something went wrong. Please try again.",
+    errorRateLimit: "Too many tries. Please wait a minute.",
+    overline: "Tell us your dream trip",
+    caption: "We'll generate a destination preview in seconds — free, no signup needed.",
+  },
+  fr: {
+    placeholder: "Je veux chiller sur une plage mexicaine avec des ruines...",
+    submit: "Imagine-le",
+    submitting: "On prépare…",
+    cta: "Planifier ce voyage",
+    retry: "Un autre pitch",
+    errorGeneric: "Une erreur est survenue. Réessaie.",
+    errorRateLimit: "Trop de tentatives. Attends une minute.",
+    overline: "Raconte ton voyage rêvé",
+    caption: "On te génère une preview de destination en quelques secondes — gratuit, sans inscription.",
+  },
+};
+
+export default function InlinePitch({ locale = "en", variant = "dark", location }: Props) {
+  const lang: Lang = locale === "fr" ? "fr" : "en";
+  const copy = COPY[lang];
+
+  const [pitch, setPitch] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [preview, setPreview] = useState<TripPreview | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (status === "success" && preview) {
+      trackEvent("inline_pitch_success", { location, destination: preview.destination });
+    }
+  }, [status, preview, location]);
+
+  const submit = async () => {
+    const trimmed = pitch.trim();
+    if (trimmed.length < 3 || status === "loading") return;
+
+    setStatus("loading");
+    setError(null);
+    trackEvent("inline_pitch_submit", { location, length: trimmed.length, locale: lang });
+
+    try {
+      const res = await fetch(`${API_URL}/api/public/trip-preview`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ pitch: trimmed, locale: lang, travel_month: null }),
+      });
+      if (res.status === 429) {
+        setError(copy.errorRateLimit);
+        setStatus("error");
+        return;
+      }
+      if (!res.ok) {
+        setError(copy.errorGeneric);
+        setStatus("error");
+        return;
+      }
+      const data = await res.json();
+      // Inline pitch ignores clarification flow — too cramped to ask follow-ups here.
+      // Treat clarification as a no-op success that bounces to the home flow instead.
+      if (data?.needs_clarification) {
+        window.location.href = `/?pitch=${encodeURIComponent(trimmed)}`;
+        return;
+      }
+      setPreview(data.preview as TripPreview);
+      setToken(data.token);
+      setStatus("success");
+    } catch {
+      setError(copy.errorGeneric);
+      setStatus("error");
+    }
+  };
+
+  const reset = () => {
+    setStatus("idle");
+    setPreview(null);
+    setToken(null);
+    setError(null);
+  };
+
+  const isLight = variant === "light";
+  const cardBg = isLight ? "bg-[#FFFBF5]/95" : "bg-white";
+  const cardText = "text-[#001E13]";
+  const subtleText = "text-[#001E13]/60";
+
+  if (status === "success" && preview) {
+    const signupUrl = token ? `${APP_URL}/register?pitch=${token}` : `${APP_URL}/register`;
+    const coverUrl = preview.cover?.urls.regular || preview.cover?.urls.small;
+
+    return (
+      <div className={`${cardBg} ${cardText} w-full max-w-xl rounded-2xl shadow-[0_20px_60px_-15px_rgba(0,0,0,0.4)] overflow-hidden flex flex-col sm:flex-row`}>
+        {coverUrl && (
+          <div className="relative w-full sm:w-32 h-32 sm:h-auto flex-shrink-0">
+            <Image src={coverUrl} alt={preview.destination} fill sizes="200px" className="object-cover" />
+          </div>
+        )}
+        <div className="flex-1 p-4 flex flex-col justify-between gap-3 text-left">
+          <div>
+            <div className="font-nanum-pen text-orange text-base leading-none mb-1">{lang === "fr" ? "Et si tu allais à…" : "What about…"}</div>
+            <div className="font-londrina-solid text-2xl leading-none mb-1">{preview.destination}</div>
+            {preview.country && (
+              <div className={`inline-flex items-center gap-1 ${subtleText} text-xs font-karla font-bold`}>
+                <MapPin className="w-3 h-3" />
+                {preview.country}
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-3 flex-wrap">
+            <Link
+              href={signupUrl}
+              onClick={() => trackEvent("inline_pitch_cta_click", { location, destination: preview.destination })}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full bg-orange hover:bg-orange/90 text-white font-karla font-bold text-sm transition-colors shadow-md shadow-orange/30"
+              rel="nofollow"
+            >
+              {copy.cta}
+              <ArrowRight className="w-3.5 h-3.5" />
+            </Link>
+            <button
+              type="button"
+              onClick={reset}
+              className={`inline-flex items-center gap-1 ${subtleText} hover:${cardText} font-karla font-semibold text-xs underline underline-offset-4`}
+            >
+              <RotateCcw className="w-3 h-3" />
+              {copy.retry}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "loading") {
+    return (
+      <div className={`${cardBg} ${cardText} w-full max-w-xl rounded-2xl shadow-[0_20px_60px_-15px_rgba(0,0,0,0.4)] px-5 py-4 flex items-center gap-3`}>
+        <Loader2 className="w-5 h-5 animate-spin text-orange flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="font-londrina-solid text-base">{copy.submitting}</div>
+          <div className={`${subtleText} text-xs font-karla italic truncate`}>&ldquo;{pitch}&rdquo;</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+      className="w-full max-w-xl"
+    >
+      <div className={`relative ${cardBg} ${cardText} rounded-2xl shadow-[0_20px_60px_-15px_rgba(0,0,0,0.4)]`}>
+        <textarea
+          value={pitch}
+          onChange={(e) => setPitch(e.target.value)}
+          placeholder={copy.placeholder}
+          maxLength={500}
+          rows={2}
+          className={`w-full resize-none rounded-2xl px-4 pt-3 pb-12 bg-transparent outline-none placeholder-gray-500 ${cardText} text-sm font-karla`}
+        />
+        <div className="absolute bottom-2 left-3 right-2 flex items-center justify-between gap-2">
+          <span className={`${subtleText} text-[10px] font-karla`}>{pitch.length}/500</span>
+          <button
+            type="submit"
+            disabled={pitch.trim().length < 3}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-orange hover:bg-orange/90 text-white font-karla font-bold text-xs transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-md shadow-orange/30"
+          >
+            <Sparkles className="w-3 h-3" />
+            {copy.submit}
+          </button>
+        </div>
+      </div>
+      {error && (
+        <p className="mt-2 text-xs text-red-100 bg-red-900/40 border border-red-400/30 rounded-lg px-3 py-1.5 font-karla" role="alert">
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/src/components/ReadyBanner.tsx
+++ b/src/components/ReadyBanner.tsx
@@ -2,8 +2,7 @@
 
 import { motion, useMotionValue, useSpring } from "framer-motion";
 import { useRef, useEffect, useMemo } from "react";
-import Link from "next/link";
-import { trackEvent } from "@/lib/tracking";
+import InlinePitch from "@/components/InlinePitch";
 
 interface Badge {
   emoji: string;
@@ -21,9 +20,10 @@ interface ReadyBannerProps {
     buttonText: string;
     buttonUrl: string;
   };
+  locale?: string;
 }
 
-export default function ReadyBanner({ data }: ReadyBannerProps) {
+export default function ReadyBanner({ data, locale }: ReadyBannerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Configurations spring différentes pour chaque badge - mémorisées pour éviter re-render
@@ -151,11 +151,9 @@ export default function ReadyBanner({ data }: ReadyBannerProps) {
               Join 12,000+ travelers planning smarter trips
             </p>
 
-            <Link href={data.buttonUrl || "https://app.weplanify.com/register"} onClick={() => trackEvent("cta_click", { location: "ready_banner", label: data.buttonText })}>
-              <button className="bg-[#EEF899] text-[#001E13] px-6 py-2 rounded-full font-karla font-bold text-sm lg:text-base hover:bg-[#EEF899]/90 transition-colors ring-4 ring-[#EEF899] ring-opacity-15">
-                {data.buttonText}
-              </button>
-            </Link>
+            <div className="flex justify-center">
+              <InlinePitch locale={locale} variant="light" location="ready_banner" />
+            </div>
 
             {/* Free forever notice */}
             <p className="text-[#FFFBF5]/60 text-xs lg:text-sm font-karla mt-3">


### PR DESCRIPTION
The home hero converts on the pitch input — type a dream, see a destination preview, click "Plan this trip" to /register?pitch=…. The same magic was absent on every other CTA (blog footer, marketing CTA banner, final ready banner), where we just shipped a static button to /register and lost the trip-preview signal.

Extract a compact <InlinePitch> with the full state machine (composer → loading → preview → reset / retry) and drop it into:

- CTASection (rendered at the bottom of every blog post)
- CTABanner (mid-page CTA on the home)
- ReadyBanner (final CTA on the home)

Each instance reuses POST /api/public/trip-preview, then hands off to /register?pitch=<token> via the existing pitch wiring on the app side, so the auto-event-creation flow keeps working transparently. A "location" prop powers three GTM events (inline_pitch_submit/success/cta_click) so the new funnels are measurable per surface.

Pages parents now thread `locale` through CTABanner / ReadyBanner / CTASection so the pitch UI matches the page locale.