### PR TITLE
feat(forms): forward UI locale to the API

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useLocale } from 'next-intl';
 import { PulsatingButton } from "@/components/magicui/pulsating-button";
 import { trackEvent } from "@/lib/tracking";
 
@@ -10,6 +11,7 @@ interface ContactFormData {
 }
 
 export default function ContactForm() {
+  const locale = useLocale();
   const [formData, setFormData] = useState<ContactFormData>({
     email: '',
     content: ''
@@ -39,7 +41,8 @@ export default function ContactForm() {
         body: JSON.stringify({
           email: formData.email,
           content: formData.content,
-          type: 'custom'
+          type: 'custom',
+          locale,
         }),
       });
 

--- a/src/components/LaunchNotificationForm.tsx
+++ b/src/components/LaunchNotificationForm.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useLocale } from 'next-intl';
 import { PulsatingButton } from "@/components/magicui/pulsating-button";
 import { trackEvent } from "@/lib/tracking";
 
 export default function LaunchNotificationForm() {
+  const locale = useLocale();
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<'idle' | 'success' | 'error'>('idle');
@@ -31,7 +33,8 @@ export default function LaunchNotificationForm() {
         },
         body: JSON.stringify({
           email: email.trim(),
-          type: 'launch_notification'
+          type: 'launch_notification',
+          locale,
         }),
       });
 

--- a/src/components/PartnershipForm.tsx
+++ b/src/components/PartnershipForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useLocale } from 'next-intl';
 import { PulsatingButton } from "@/components/magicui/pulsating-button";
 import { trackEvent } from "@/lib/tracking";
 
@@ -39,6 +40,7 @@ function buildContent(data: PartnershipFormData): string {
 }
 
 export default function PartnershipForm() {
+  const locale = useLocale();
   const [formData, setFormData] = useState<PartnershipFormData>({
     email: '',
     company: '',
@@ -73,6 +75,7 @@ export default function PartnershipForm() {
           email: formData.email,
           content: buildContent(formData),
           type: 'partnership',
+          locale,
         }),
       });
 


### PR DESCRIPTION
## Summary

Adds the current \`next-intl\` locale to the body of the 3 forms that hit \`api.weplanify.com/api/contact/request\`:

- \`LaunchNotificationForm\`
- \`ContactForm\` (custom)
- \`PartnershipForm\`

## Why

The backend already knows the geo-IP \`country\` (FR/US/etc.) but that's a poor proxy for UI language — Belgian and Swiss francophones get \`country=BE\`/\`CH\`. The user has already picked a language by being on \`/fr\` or \`/en\` so we just forward that signal.

Pairs with backend [PR #262](https://github.com/eguth-io/weplanify-backend/pull/262) which adds the \`locale\` column on \`contact_requests\` and validates \`fr|en\`. The backend currently accepts the field as nullable, so this PR can ship independently — but the value won't be persisted until #262 lands.

## Notes

- Newsletter form in the Footer is left as-is — it still doesn't post to the API (\`TODO\` in code). Wire it up later, locale at the same time.
- Pitch forms (Hero/Inline) hit a separate Next API route, not the contact endpoint, so they aren't affected here.

## Test plan

- [x] \`next lint\` clean on all 3 files
- [ ] Submit each form from \`/fr\` → DevTools → check request body includes \`locale: "fr"\`
- [ ] Same from \`/en\` → \`locale: "en"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)