### PR TITLE
feat(analytics): foundation — typed catalog, SPA page views, GTM env, PII strip

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,12 @@
 # Cloudflare Turnstile
 # Get your site key from: https://dash.cloudflare.com/?to=/:account/turnstile
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=your_site_key_here
+
+# Google Tag Manager container ID (e.g. GTM-XXXXXXX)
+# Falls back to the production container if unset.
+NEXT_PUBLIC_GTM_ID=GTM-MJHJL7Q2
+
+# OpenUI engine on the hero (engine=openui in URL/select toggle)
+# Required only when testing the OpenUI variant of the trip preview.
+OPENAI_API_KEY=
+OPENUI_TRIP_PREVIEW_MODEL=gpt-4o-mini

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { Raleway, Unbounded, Londrina_Solid, Karla, Nanum_Pen_Script } from "nex
 import "../globals.css";
 import { generateMetadataFromSanity } from "@/lib/metadata";
 import { Analytics } from "@/components/Analytics";
+import { PageViewTracker } from "@/lib/analytics/page-view-tracker";
 import CookieConsent from "@/components/CookieConsent";
 import StickyCTA from "@/components/StickyCTA";
 import { StructuredData } from "@/components/StructuredData";
@@ -97,6 +98,8 @@ export default async function LocaleLayout({ children, params }: Props) {
         <CookieConsent />
         {/* Analytics Scripts — only loads after consent */}
         <Analytics />
+        {/* Tracks SPA navigations as page_view events */}
+        <PageViewTracker />
       </body>
     </html>
   );

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -2,7 +2,7 @@
 
 import Script from "next/script";
 
-const GTM_ID = "GTM-MJHJL7Q2";
+const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID ?? "GTM-MJHJL7Q2";
 
 /**
  * Analytics component — always loads GTM with consent defaults set to "denied".

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -105,7 +105,7 @@ export default function Footer({ footerData }: FooterProps) {
     e.preventDefault();
     // TODO: Integrate with newsletter service
     if (email) {
-      trackEvent("newsletter_subscribe", { email });
+      trackEvent("newsletter_subscribe");
       setIsSubscribed(true);
       setEmail("");
     }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,49 @@
+/**
+ * Typed catalog of every custom analytics event the landing emits.
+ *
+ * Keep this map in sync with the GTM container — when adding a new event,
+ * also add a tag/trigger in GTM and (where it makes sense) register the
+ * params as Custom Definitions in GA4 so they're queryable in reports.
+ *
+ * Niveau 2 will introduce a unified form schema (form_start / form_submit /
+ * generate_lead) — the legacy `*_form_submit` and `newsletter_subscribe`
+ * events live here for now to avoid breaking GTM tags configured against
+ * the current names.
+ */
+
+type FormStatus = "success" | "error";
+
+export type EventCatalog = {
+  // Page views fired client-side on SPA navigation by PageViewTracker.
+  // The very first page view is left to GTM/GA4 native to avoid double counting.
+  page_view: { path: string; locale: string; search?: string };
+
+  // Generic CTAs (sticky, hero, etc.) — `location` discriminates the surface.
+  cta_click: { location: string; label: string };
+
+  // Pitch flow — hero
+  hero_pitch_submit: { length: number; locale: string };
+  hero_pitch_needs_clarification: { locale: string };
+  hero_pitch_success: { destination: string };
+  hero_pitch_cta_click: { destination: string };
+
+  // Pitch flow — inline (in-page sections)
+  inline_pitch_submit: { location: string; length: number; locale: string };
+  inline_pitch_success: { location: string; destination: string };
+  inline_pitch_cta_click: { location: string; destination: string };
+
+  // Content engagement
+  faq_toggle: { question: string };
+  related_feature_click: { from: string; to: string };
+  blog_article_click: { title: string };
+
+  // Forms (legacy names — to be unified in Niveau 2)
+  contact_form_submit: { status: FormStatus };
+  launch_notification_submit: { status: FormStatus };
+  partnership_form_submit: { status: FormStatus };
+  // Newsletter intentionally carries no payload — never send the email
+  // (PII leak into dataLayer / GTM / GA4).
+  newsletter_subscribe: void;
+};
+
+export type EventName = keyof EventCatalog;

--- a/src/lib/analytics/page-view-tracker.tsx
+++ b/src/lib/analytics/page-view-tracker.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useLocale } from "next-intl";
+import { trackEvent } from "@/lib/tracking";
+
+function PageViewTrackerInner() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const locale = useLocale();
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    // Skip the first effect: GTM/GA4 already fire a page_view on initial
+    // page load. We only emit for client-side (SPA) navigations to avoid
+    // double-counting the entry view.
+    if (!initialized.current) {
+      initialized.current = true;
+      return;
+    }
+
+    const search = searchParams?.toString();
+    trackEvent("page_view", {
+      path: pathname ?? "/",
+      locale,
+      search: search && search.length > 0 ? search : undefined,
+    });
+  }, [pathname, searchParams, locale]);
+
+  return null;
+}
+
+/**
+ * Emits a `page_view` event on every SPA navigation under the App Router.
+ * Mounts once near the root layout. Wrapped in Suspense because
+ * `useSearchParams()` requires it during static rendering.
+ */
+export function PageViewTracker() {
+  return (
+    <Suspense fallback={null}>
+      <PageViewTrackerInner />
+    </Suspense>
+  );
+}

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,13 +1,24 @@
+import type { EventCatalog, EventName } from "./analytics/events";
+
 /**
  * Push a custom event to the GTM dataLayer.
- * Safe to call server-side (no-ops silently).
+ *
+ * Typed against `EventCatalog` so call sites can't pass an unknown event
+ * name or a wrong payload shape. Server-side calls are silently no-ops.
+ *
+ * Consent is enforced by Google Consent Mode v2 inside GTM — we always
+ * push to dataLayer; GTM withholds tag firing until consent is granted.
  */
-export function trackEvent(
-  event: string,
-  params?: Record<string, string | number | boolean>
-) {
+export function trackEvent<E extends EventName>(
+  event: E,
+  ...rest: EventCatalog[E] extends void
+    ? []
+    : [payload: EventCatalog[E]]
+): void {
   if (typeof window === "undefined") return;
   const w = window as unknown as { dataLayer?: Record<string, unknown>[] };
   w.dataLayer = w.dataLayer || [];
-  w.dataLayer.push({ event, ...params });
+  w.dataLayer.push({ event, ...((rest[0] as Record<string, unknown> | undefined) ?? {}) });
 }
+
+export type { EventCatalog, EventName } from "./analytics/events";


### PR DESCRIPTION
## Summary

Niveau 1 of the analytics overhaul. Sets up the basics so future events are typed at compile time, SPA navigations are tracked (App Router doesn't fire GA \`page_view\` natively on client-side routes), and we stop shipping PII into \`dataLayer\`.

## What's in

| File | Change |
|---|---|
| \`src/lib/analytics/events.ts\` | **New.** TypeScript catalog of every custom event the landing emits, with payload shapes. Single source of truth for the GTM contract. |
| \`src/lib/tracking.ts\` | Generic \`trackEvent<E>(name, payload)\` enforced against the catalog. Wrong event name or wrong payload shape = compile error. |
| \`src/lib/analytics/page-view-tracker.tsx\` | **New.** Client component listens to \`usePathname\` + \`useSearchParams\` and emits \`page_view\` on every SPA navigation. Skips the first effect to avoid double-counting GTM/GA4's native initial pageview. Wrapped in Suspense so static prerendering is preserved. |
| \`src/components/Analytics.tsx\` | GTM container ID moved to \`NEXT_PUBLIC_GTM_ID\` env var (current prod ID kept as fallback so nothing breaks if env unset). |
| \`.env.example\` | Documents \`NEXT_PUBLIC_GTM_ID\`. |
| \`src/components/Footer.tsx\` | Newsletter event no longer ships \`{ email }\` — \`newsletter_subscribe\` now fires with no payload (RGPD-clean). |
| \`src/app/[locale]/layout.tsx\` | Mounts \`<PageViewTracker />\` once, sibling of \`<Analytics />\`. |

## Why

From the GA4 audit done earlier:

- **PII leak**: \`newsletter_subscribe\` was pushing the user's email into \`dataLayer\` → fed into GTM/GA4 — RGPD problem.
- **GTM_ID hardcoded**: no separation between dev/staging/prod.
- **No SPA page_view tracking**: under App Router, GA4 fires only on initial page load, missing every client-side route change.
- **No event-name discipline**: 6 different naming conventions for form submits, easy to typo. A typed catalog stops that at compile time.

## Test plan

- [x] \`tsc --noEmit\` clean (catalog matches every existing call site).
- [x] \`next lint\` clean on touched files.
- [x] \`next build\` succeeds; every locale route still SSG-prerendered.
- [ ] Local: open DevTools → navigate \`/en\` → \`/fr\` → \`/en/blog\` → confirm \`page_view\` events appear in dataLayer with correct path/locale.
- [ ] Confirm initial page load still gets GA4's native \`page_view\` (not double-counted by ours).
- [ ] Submit the newsletter form → confirm \`newsletter_subscribe\` event has no \`email\` field anymore.

## What this PR does NOT do (Niveau 2+ later)

- Unified \`form_start\` / \`form_submit\` / \`generate_lead\` schema across the 4 forms
- Cross-domain stitching (\`weplanify.com\` ↔ \`app.weplanify.com\`)
- Pitch funnel as a proper \`pitch_started → pitch_generated → pitch_cta_click\` sequence
- GA4 admin work (register Custom Definitions for \`cta_id\`, \`destination\`, etc., mark conversions, exclude internal traffic) — that's a checklist to apply in the GA4 UI, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)