### PR TITLE
fix(analytics): page-view tracker crashed render via useLocale outside provider

### DIFF
--- a/src/lib/analytics/page-view-tracker.tsx
+++ b/src/lib/analytics/page-view-tracker.tsx
@@ -2,13 +2,17 @@
 
 import { Suspense, useEffect, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useLocale } from "next-intl";
 import { trackEvent } from "@/lib/tracking";
+
+function localeFromPath(pathname: string | null): string {
+  if (!pathname) return "en";
+  const seg = pathname.split("/")[1];
+  return seg === "fr" ? "fr" : "en";
+}
 
 function PageViewTrackerInner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const locale = useLocale();
   const initialized = useRef(false);
 
   useEffect(() => {
@@ -23,10 +27,10 @@ function PageViewTrackerInner() {
     const search = searchParams?.toString();
     trackEvent("page_view", {
       path: pathname ?? "/",
-      locale,
+      locale: localeFromPath(pathname),
       search: search && search.length > 0 ? search : undefined,
     });
-  }, [pathname, searchParams, locale]);
+  }, [pathname, searchParams]);
 
   return null;
 }
@@ -35,6 +39,13 @@ function PageViewTrackerInner() {
  * Emits a `page_view` event on every SPA navigation under the App Router.
  * Mounts once near the root layout. Wrapped in Suspense because
  * `useSearchParams()` requires it during static rendering.
+ *
+ * Locale is derived from the URL pathname segment instead of `useLocale()`
+ * from next-intl: the tracker is mounted as a sibling of the locale layout's
+ * `<NextIntlClientProvider>`, not a descendant, so the next-intl context
+ * isn't available here. Reading the segment keeps the component
+ * self-sufficient and avoids a render crash if it's mounted outside the
+ * provider.
  */
 export function PageViewTracker() {
   return (


### PR DESCRIPTION
## Summary

Production prints a stack-traced \`Error\` on every page load since PR #50 deployed. Cause: \`PageViewTracker\` calls \`useLocale()\` from next-intl, but it's mounted as a **sibling** of \`<NextIntlClientProvider>\` in the locale layout, not a descendant. The hook throws, React commit phase reports an empty \`Error\`, console gets noisy on every visit.

## Diagnostic captured live

\`\`\`
Error
  at .../7125-2a016758eba7e03b.js:1:10027   ← useLocale() throws
  at v (.../7125-2a016758eba7e03b.js:1:10050)
  at i (.../app/[locale]/layout-edf8204803015c6e.js:1:12353)
  at ll (.../4bd1b696-58a58df96c40771e.js:1:34824)   ← React renderRoot
  at aZ / ol / uu / ui (...)                          ← React commit
\`\`\`

Reproduced on \`https://www.weplanify.com/en\` (deployment \`dpl_DmZHHG658MnvKuKWu5p8VwD9VoTU\`). Empty error message is React's default when a thrown render error is forwarded.

## Fix

Drop \`useLocale()\` and derive the locale from \`usePathname()\`'s first segment instead:

\`\`\`ts
function localeFromPath(pathname: string | null): string {
  if (!pathname) return \"en\";
  const seg = pathname.split(\"/\")[1];
  return seg === \"fr\" ? \"fr\" : \"en\";
}
\`\`\`

The tracker is now self-sufficient — works anywhere in the tree, no context dependency.

## Why not just move \`<PageViewTracker />\` inside the provider?

Either fix would work, but moving it inside changes layout structure for the next person to touch it; making the component context-free is more durable and a smaller diff (1 file, +15 -4).

## Test plan

- [x] \`next lint\` clean.
- [x] \`tsc --noEmit\` clean.
- [x] \`next build\` succeeds, SSG preserved.
- [ ] On Vercel preview, visit any page → confirm no \`Error\` in console.
- [ ] Navigate \`/en\` → \`/fr\` → \`/en/blog\` → confirm \`page_view\` events fire with correct \`locale\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)