### PR TITLE
feat(seo): rewrite alternative pages titles + meta for higher CTR

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -22,14 +22,14 @@ export function generateStaticParams() {
 
 const aboutMeta = {
   en: {
-    title: "About WePlanify — Our Mission & Team | WePlanify",
+    title: "About WePlanify — The Free Group Trip Planner for Friends",
     description:
-      "WePlanify is the group trip planner built for friends, families, and teams. Learn about our mission, our team, and why we're building the future of collaborative travel planning.",
+      "WePlanify is the free, collaborative trip planner for friends, families and teams. Discover the story, the mission and the team behind real-time group travel planning.",
   },
   fr: {
-    title: "À Propos de WePlanify — Notre Mission & Équipe | WePlanify",
+    title: "À Propos de WePlanify — Le Planificateur de Voyage de Groupe",
     description:
-      "WePlanify est le planificateur de voyage de groupe conçu pour les amis, les familles et les équipes. Découvrez notre mission, notre équipe et pourquoi nous construisons le futur de la planification collaborative.",
+      "WePlanify est le planificateur de voyage de groupe gratuit et collaboratif pour amis, familles et équipes. Découvrez l'histoire, la mission et l'équipe derrière l'app.",
   },
 };
 

--- a/src/app/[locale]/alternatives/cruzmi/page.tsx
+++ b/src/app/[locale]/alternatives/cruzmi/page.tsx
@@ -47,15 +47,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const meta = {
     en: {
       title:
-        "WePlanify vs Cruzmi — Best French Group Trip Planner? (2026)",
+        "Cruzmi Alternative for Group Trips: WePlanify (Free, 2026)",
       description:
-        "WePlanify vs Cruzmi: detailed comparison of two French-speaking group trip planning apps. Compare features, itineraries, polls, budgets and more.",
+        "Cruzmi alternative for organizing group trips with friends. WePlanify offers collaborative itineraries, polls, shared budgets and packing lists — free, bilingual (EN/FR).",
     },
     fr: {
       title:
-        "WePlanify vs Cruzmi — Meilleur Organisateur de Voyage de Groupe Français ? (2026)",
+        "Alternative à Cruzmi : Voyage de Groupe Collaboratif (Gratuit, 2026)",
       description:
-        "WePlanify vs Cruzmi : comparatif complet de deux applications francophones pour organiser un voyage de groupe. Fonctionnalités, itinéraires, sondages, budgets et plus.",
+        "Alternative à Cruzmi pour vos voyages de groupe entre amis. WePlanify : itinéraires collaboratifs, sondages, budget partagé, packing list — gratuit, bilingue FR/EN.",
     },
   };
 

--- a/src/app/[locale]/alternatives/squadtrip/page.tsx
+++ b/src/app/[locale]/alternatives/squadtrip/page.tsx
@@ -47,15 +47,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const meta = {
     en: {
       title:
-        "WePlanify vs SquadTrip — Best Free Group Trip Planner? (2026)",
+        "SquadTrip Alternative: Free Group Trip Planner (2026) | WePlanify",
       description:
-        "Detailed comparison of WePlanify and SquadTrip for group trip planning. See which free group travel app offers the best collaborative features, polls, budgets, and more.",
+        "Looking for a SquadTrip alternative? WePlanify offers real-time itineraries, shared polls, group budgets and packing lists — free, bilingual (EN/FR).",
     },
     fr: {
       title:
-        "WePlanify vs SquadTrip — Meilleur Organisateur de Voyage de Groupe Gratuit ? (2026)",
+        "Alternative à SquadTrip : Voyage de Groupe Gratuit (2026)",
       description:
-        "Comparatif détaillé entre WePlanify et SquadTrip pour organiser un voyage de groupe. Découvrez quelle application gratuite offre les meilleures fonctionnalités collaboratives.",
+        "Alternative à SquadTrip pour organiser un voyage de groupe. WePlanify : itinéraire collaboratif, sondages, budget partagé. Gratuit, bilingue FR/EN.",
     },
   };
 

--- a/src/app/[locale]/alternatives/stippl/page.tsx
+++ b/src/app/[locale]/alternatives/stippl/page.tsx
@@ -47,15 +47,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const meta = {
     en: {
       title:
-        "WePlanify vs Stippl \u2014 Which Travel Planner Is Best for Groups? (2026)",
+        "Stippl Alternative for Groups: Free Collaborative Planner (2026)",
       description:
-        "Detailed comparison of WePlanify and Stippl for group trip planning. Features, pricing, and which travel planner is best for your group.",
+        "Looking for a Stippl alternative built for group trips? WePlanify adds real-time collaboration, polls, shared budgets and packing lists \u2014 free, bilingual (EN/FR).",
     },
     fr: {
       title:
-        "WePlanify vs Stippl \u2014 Quel Planificateur de Voyage Choisir pour un Groupe ? (2026)",
+        "Alternative \u00e0 Stippl : Planificateur de Voyage de Groupe (2026)",
       description:
-        "Comparaison d\u00e9taill\u00e9e entre WePlanify et Stippl pour organiser un voyage de groupe. Fonctionnalit\u00e9s, prix et quel planificateur choisir.",
+        "Alternative \u00e0 Stippl pour organiser un voyage de groupe. WePlanify : itin\u00e9raires collaboratifs, sondages, budget partag\u00e9, packing list. Gratuit, bilingue FR/EN.",
     },
   };
 

--- a/src/app/[locale]/alternatives/tripit/page.tsx
+++ b/src/app/[locale]/alternatives/tripit/page.tsx
@@ -39,15 +39,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const meta = {
     en: {
       title:
-        "WePlanify vs TripIt — Best Group Trip Organizer? (2026)",
+        "TripIt Alternative: Free Group Trip Planner (2026) | WePlanify",
       description:
-        "Detailed comparison of WePlanify and TripIt for group travel planning. See how collaborative polls, shared budgets, and real-time planning stack up against TripIt's booking import and flight alerts.",
+        "Looking for a TripIt alternative built for group travel? WePlanify adds real-time collaboration, shared polls, group budgets and itineraries — free, bilingual (EN/FR).",
     },
     fr: {
       title:
-        "WePlanify vs TripIt — Meilleur Organisateur de Voyage de Groupe ? (2026)",
+        "Alternative à TripIt : Voyage de Groupe Collaboratif (2026)",
       description:
-        "Comparatif détaillé entre WePlanify et TripIt pour organiser un voyage de groupe. Découvrez les différences entre sondages collaboratifs, budgets partagés et les alertes de vol de TripIt.",
+        "Cherchez une alternative à TripIt pour organiser un voyage de groupe ? WePlanify : sondages, budget partagé, itinéraire collaboratif en temps réel. Gratuit, FR/EN.",
     },
   };
 

--- a/src/app/[locale]/alternatives/wanderlog/page.tsx
+++ b/src/app/[locale]/alternatives/wanderlog/page.tsx
@@ -47,15 +47,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const meta = {
     en: {
       title:
-        "WePlanify vs Wanderlog \u2014 Which Group Trip Planner Is Better? (2026)",
+        "Wanderlog Alternative: Free Group Trip Planner (2026) | WePlanify",
       description:
-        "Detailed comparison of WePlanify and Wanderlog for group trip planning. Features, pricing, and which app is best for your travel group.",
+        "Looking for a Wanderlog alternative for group trips? WePlanify offers real-time collaborative itineraries, shared budgets, polls and packing lists \u2014 free, bilingual (EN/FR).",
     },
     fr: {
       title:
-        "WePlanify vs Wanderlog \u2014 Quel Planificateur de Voyage de Groupe Choisir ? (2026)",
+        "Alternative \u00e0 Wanderlog : Voyage de Groupe Collaboratif (2026)",
       description:
-        "Comparaison d\u00e9taill\u00e9e entre WePlanify et Wanderlog pour organiser un voyage de groupe. Fonctionnalit\u00e9s, prix et quelle application choisir.",
+        "Cherchez une alternative \u00e0 Wanderlog pour vos voyages de groupe ? WePlanify : itin\u00e9raire collaboratif en temps r\u00e9el, sondages, budget partag\u00e9, packing list. Gratuit, FR/EN.",
     },
   };
 


### PR DESCRIPTION
Pivot from "WePlanify vs X — Question? (2026)" to "X Alternative: [Benefit] (2026)" to match search intent ("wanderlog alternative" >> "weplanify vs wanderlog"). Front-load competitor name, add free + bilingual hooks in descriptions.

Pages: wanderlog, stippl, tripit, cruzmi, squadtrip alternatives + about (EN + FR).

Based on GSC analysis (Apr 13 - May 8 2026):
- /alternatives/wanderlog: 172 imp, 0 clicks, pos 6.7
- /alternatives/stippl: 80 imp, 0 clicks, pos 6.7
- /alternatives/tripit: 60 imp, 0 clicks, pos 17
- /alternatives/squadtrip: 103 imp, 2 clicks, pos 7.2
- /alternatives/cruzmi: 19 imp, 0 clicks, pos 4.6
- /about: 151 imp, 0 clicks, pos 5.4