### PR TITLE
feat(seo): add 3 event-driven 2026 trip planner landing pages

### DIFF
--- a/src/app/[locale]/hellfest-2026-trip-planner/page.tsx
+++ b/src/app/[locale]/hellfest-2026-trip-planner/page.tsx
@@ -1,0 +1,603 @@
+import { Metadata } from "next";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { sanityFetch } from "@/sanity/lib/fetch";
+import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
+import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
+import { PulsatingButton } from "@/components/magicui/pulsating-button";
+import Link from "next/link";
+import Breadcrumb from "@/components/Breadcrumb";
+import ArticleTOC from "@/components/ArticleTOC";
+import { setRequestLocale } from "next-intl/server";
+import { generateMetadataFromSanity } from "@/lib/metadata";
+import { routing } from "@/i18n/routing";
+import FadeIn from "@/components/FadeIn";
+import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
+
+type Props = { params: Promise<{ locale: string }> };
+const SITE_URL = "https://www.weplanify.com";
+const PATHNAME = "/hellfest-2026-trip-planner";
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const metadata = await generateMetadataFromSanity(locale, PATHNAME);
+  const isEn = locale === "en";
+  const title = isEn
+    ? "Hellfest 2026: The Trip Planner for Clisson — Travel, Camping & Group Budget | WePlanify"
+    : "Hellfest 2026 : Le Guide Voyage à Clisson — Transports, Camping et Budget Partagé | WePlanify";
+  const description = isEn
+    ? "Everything for Hellfest 2026 (18–21 June, Clisson): sold-out resale plan, TGV from Paris/Brussels, Clisson shuttles, camping vs Nantes hotels, cashless system and shared group budget for the metal pilgrimage."
+    : "Tout sur le Hellfest 2026 (18-21 juin, Clisson) : plan revente sur la billetterie sold out, TGV depuis Paris/Bruxelles, navettes Clisson, camping vs hôtels Nantes, cashless et budget partagé pour le pèlerinage metal entre potes.";
+  const currentUrl = `${SITE_URL}/${locale}${PATHNAME}`;
+  return {
+    ...metadata, title, description,
+    authors: [{ name: "Alex Martin" }],
+    openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl },
+    twitter: { ...metadata.twitter, title, description },
+    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+  };
+}
+
+export default async function Hellfest2026Page({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const isEn = locale === "en";
+
+  const [navData, navigationData, footerData]: [NavType, Navigation | null, FooterType | null] =
+    await Promise.all([
+      sanityFetch<NavType>({ query: navQuery, params: { locale }, tags: ["nav"] }),
+      sanityFetch<Navigation>({ query: navigationQuery, params: { locale }, tags: ["navigation"] }),
+      sanityFetch<FooterType>({ query: footerQuery, params: { locale }, tags: ["footer"] }),
+    ]);
+
+  const breadcrumbLd = {
+    "@context": "https://schema.org", "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: isEn ? "Home" : "Accueil", item: `${SITE_URL}/${locale}` },
+      { "@type": "ListItem", position: 2, name: isEn ? "Hellfest 2026 Trip Planner" : "Voyage Hellfest 2026", item: `${SITE_URL}/${locale}${PATHNAME}` },
+    ],
+  };
+
+  const articleLd = {
+    "@context": "https://schema.org", "@type": "Article",
+    headline: isEn ? "Hellfest 2026: The Trip Planner for Clisson" : "Hellfest 2026 : Le Guide Voyage à Clisson",
+    author: { "@type": "Person", name: "Alex Martin", jobTitle: "Travel Editor" },
+    publisher: { "@type": "Organization", name: "WePlanify", url: SITE_URL },
+    datePublished: "2026-05-13", dateModified: "2026-05-13",
+    mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}/${locale}${PATHNAME}` },
+  };
+
+  const musicEventLd = {
+    "@context": "https://schema.org",
+    "@type": "MusicFestival",
+    name: "Hellfest Open Air Festival 2026",
+    description: isEn
+      ? "Hellfest 2026, the four-day metal and rock festival at the Val de Moine in Clisson, France, from 18 to 21 June 2026. 183 artists across 6 stages, headlined by Bring Me The Horizon, Iron Maiden, Limp Bizkit and The Offspring."
+      : "Hellfest 2026, le festival metal et rock de quatre jours au Val de Moine à Clisson, France, du 18 au 21 juin 2026. 183 artistes sur 6 scènes, têtes d'affiche Bring Me The Horizon, Iron Maiden, Limp Bizkit et The Offspring.",
+    image: [`${SITE_URL}/header-bg.webp`],
+    startDate: "2026-06-18",
+    endDate: "2026-06-21",
+    eventStatus: "https://schema.org/EventScheduled",
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    organizer: { "@type": "Organization", name: "Hellfest Productions", url: "https://hellfest.fr" },
+    offers: {
+      "@type": "Offer",
+      url: "https://tickets.hellfest.fr",
+      availability: "https://schema.org/SoldOut",
+      validFrom: "2025-10-01",
+    },
+    location: {
+      "@type": "Place",
+      name: "Val de Moine",
+      address: { "@type": "PostalAddress", addressLocality: "Clisson", addressRegion: "Pays de la Loire", addressCountry: "FR" },
+    },
+  };
+
+  const faqItems = isEn
+    ? [
+        { q: "When and where is Hellfest 2026?", a: "Thursday 18 to Sunday 21 June 2026 at the Val de Moine in Clisson, a small wine-growing town in Loire-Atlantique, about 30 km southeast of Nantes. The site covers 21 hectares and runs 6 stages with 183 artists over the four days. Longest daylight of the year — the sun sets close to 22:00 local time, perfect for the late-night main-stage closers." },
+        { q: "Is Hellfest 2026 sold out and how do I still get a ticket?", a: "Yes. Both the 4-day passes and the single-day passes are sold out, and the premium Easy Camp accommodation is also gone. The only legitimate way to find a ticket now is the official resale platform on tickets.hellfest.fr — listings appear when other fans cancel, sometimes daily, sometimes only days before the festival. Avoid Telegram groups, Facebook marketplace and Vinted: counterfeit tickets are widely reported and won't pass the gate scan." },
+        { q: "How do I get to Clisson from Paris, Lille or Brussels?", a: "The fastest route is TGV INOUI or Ouigo from Paris-Montparnasse to Nantes — 2h00 to 2h26, fares from around €16 on Ouigo if booked early, €40-90 closer to the date. From Lille, count on a direct TGV in about 4h. From Brussels, one direct TGV per day, around 4h47. From Nantes you then take a regional TER to Clisson — every hour, 16-30 minutes — and during the festival a special 'Live' ticket caps any Pays de la Loire TER trip to/from Clisson at €5." },
+        { q: "Where should I stay around the festival?", a: "Three options. Camping classique is included in the 4-day pass — basic but the heart of the Hellfest experience. Premium Easy Camp (tipis, chalets, tiny rooms) is sold out for 2026. Off-site, Nantes hotels (30 km away) average around €130-180/night during festival weekend, up 20-60% from normal rates, and you'll need to factor in transport time both ways. A serviced apartment split with the crew often comes out best on price." },
+        { q: "How does the Hellfest cashless system work?", a: "The site is 100% cashless and the only payment method is your festival wristband. Top it up online at cashless.hellfest.fr (no fee on top-ups after the first) or at on-site banks. The first activation costs €1.50. There are very few ATMs on-site — Hell City Square and the Clisson supermarket — and queues are long, so top up before you arrive. Unspent balance is refundable after the festival within the announced window." },
+        { q: "What's the weather like in Clisson in mid-June?", a: "Warm days around 22-24°C, cool nights around 12-13°C, with roughly 11 rainy days across the month so a light rain jacket is non-negotiable. The site is open with little shade — bring sunscreen, a refillable water bottle and a hat. The longest days of the year mean ~16 hours of daylight, perfect for the festival rhythm but rough on phone batteries." },
+        { q: "How do you organise a Hellfest trip with a group of friends?", a: "Resale tickets are individual — keep them out of the shared pool. The shared pool is for the TGV, hotel or apartment, on-site cashless top-ups, group meals in Nantes before or after, and the rental car or shuttle. Set categories from day one (transport, accommodation, food, cashless float) so the math doesn't collapse on the way home. WePlanify keeps each category clean and lets the group front expenses by rotation." },
+      ]
+    : [
+        { q: "Quand et où se tient le Hellfest 2026 ?", a: "Du jeudi 18 au dimanche 21 juin 2026 au Val de Moine à Clisson, une petite ville viticole de Loire-Atlantique, à environ 30 km au sud-est de Nantes. Le site fait 21 hectares avec 6 scènes et 183 artistes sur les quatre jours. C'est la période la plus longue de l'année en lumière du jour — le soleil se couche autour de 22h, idéal pour les concerts de tête d'affiche en plein air." },
+        { q: "Le Hellfest 2026 est-il sold out, comment trouver un billet ?", a: "Oui. Les pass 4 jours et les pass 1 jour sont sold out, et l'hébergement premium Easy Camp aussi. La seule façon légitime d'avoir un billet maintenant, c'est la billetterie officielle de revente sur tickets.hellfest.fr — des billets réapparaissent quand des festivaliers annulent, parfois quotidiennement, parfois quelques jours avant l'événement. Évitez Telegram, Marketplace et Vinted : les faux billets sont massifs et ne passent pas le scan d'entrée." },
+        { q: "Comment rejoindre Clisson depuis Paris, Lille ou Bruxelles ?", a: "Le plus rapide, c'est TGV INOUI ou Ouigo depuis Paris-Montparnasse jusqu'à Nantes — 2h00 à 2h26, prix à partir de 16 € sur Ouigo en s'y prenant tôt, 40-90 € à l'approche. Depuis Lille, comptez un TGV direct en 4h environ. Depuis Bruxelles, un seul TGV direct par jour, environ 4h47. De Nantes vous prenez ensuite un TER jusqu'à Clisson — toutes les heures, 16 à 30 minutes — et pendant le festival un billet spécial 'Live' plafonne tout trajet TER Pays de la Loire vers/depuis Clisson à 5 €." },
+        { q: "Où dormir autour du festival ?", a: "Trois options. Le camping classique est inclus dans le pass 4 jours — basique mais c'est le cœur de l'expérience Hellfest. L'Easy Camp premium (tipis, chalets, tiny rooms) est sold out pour 2026. Hors site, les hôtels nantais (30 km) tournent autour de 130-180 €/nuit sur le week-end, soit +20 à 60 % par rapport au tarif normal, et il faut compter le trajet aller-retour. Un appartement partagé entre potes ressort souvent comme la meilleure option budget." },
+        { q: "Comment fonctionne le cashless du Hellfest ?", a: "Le site est 100 % cashless, le seul moyen de paiement c'est votre bracelet. Vous le rechargez sur cashless.hellfest.fr (pas de frais sur les rechargements suivants) ou aux banques cashless sur place. Première activation à 1,50 €. Très peu de DAB sur le site — Hell City Square et le supermarché de Clisson — et les files sont longues, donc rechargez avant d'arriver. Le solde non utilisé est remboursable après le festival dans la fenêtre annoncée." },
+        { q: "Quelle météo prévoir à Clisson mi-juin ?", a: "Journées douces autour de 22-24°C, nuits fraîches autour de 12-13°C, et environ 11 jours de pluie sur le mois donc un coupe-vent imperméable est indispensable. Le site est ouvert avec peu d'ombre — crème solaire, gourde et casquette obligatoires. Les journées les plus longues de l'année (~16 h de jour) rythment bien le festival mais épuisent les batteries de téléphone." },
+        { q: "Comment organiser un Hellfest entre potes ?", a: "Les billets de revente sont individuels — gardez-les hors du pot commun. Le pot commun, c'est pour le TGV, l'hôtel ou l'appartement, les rechargements cashless, les restos à Nantes avant et après, et la voiture de location ou la navette. Posez les catégories dès le départ (transport, hébergement, restos, float cashless) pour ne pas finir le calcul au retour. WePlanify garde chaque catégorie au propre et permet de faire tourner les avances dans le groupe." },
+      ];
+
+  const faqLd = {
+    "@context": "https://schema.org", "@type": "FAQPage",
+    mainEntity: faqItems.map((item) => ({ "@type": "Question", name: item.q, acceptedAnswer: { "@type": "Answer", text: item.a } })),
+  };
+
+  const howToLd = {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: isEn ? "How to plan a Hellfest 2026 trip to Clisson" : "Comment organiser un voyage au Hellfest 2026 à Clisson",
+    description: isEn
+      ? "Five weeks out, here is how to lock the trip: ticket-resale watch, TGV from Paris, Clisson logistics, group budget setup and a cashless float plan."
+      : "À cinq semaines, voici comment verrouiller le voyage : veille billetterie revente, TGV depuis Paris, logistique Clisson, budget partagé et float cashless.",
+    totalTime: "PT45M",
+    step: [
+      {
+        "@type": "HowToStep",
+        position: 1,
+        name: isEn ? "Map who has a ticket and who is still hunting" : "Identifier qui a un billet et qui en cherche encore",
+        text: isEn
+          ? "Hellfest is sold out — run a quick poll in the group to flag who is confirmed, who is waiting on the official resale, and who is going regardless to camp and enjoy the village. The answer drives flights, room split and rental car size."
+          : "Hellfest est sold out — lancez un sondage rapide dans le groupe pour distinguer qui est confirmé, qui attend un billet sur la revente officielle, et qui descend de toute façon pour camper et profiter du village. La réponse pilote tout : transport, chambres, taille de la voiture.",
+        url: `${SITE_URL}/${locale}/features/polls`,
+      },
+      {
+        "@type": "HowToStep",
+        position: 2,
+        name: isEn ? "Book TGV and accommodation before they slip" : "Réserver TGV et hébergement avant qu'ils ne s'envolent",
+        text: isEn
+          ? "Paris–Nantes Ouigo and TGV INOUI are still bookable but climb fast on the Wed/Thu departures and the Sun/Mon returns. Lock one outbound and one return for the whole crew, plus a Nantes apartment or hotel block within 30 minutes of the TER to Clisson."
+          : "Les Paris-Nantes Ouigo et TGV INOUI sont encore réservables mais grimpent vite sur les départs mer/jeu et les retours dim/lun. Verrouillez un même aller et un même retour pour toute la bande, plus un appartement ou un bloc d'hôtel à Nantes à moins de 30 minutes du TER vers Clisson.",
+        url: `${SITE_URL}/${locale}/features/itinerary`,
+      },
+      {
+        "@type": "HowToStep",
+        position: 3,
+        name: isEn ? "Set a shared budget with a cashless float category" : "Mettre en place un budget partagé avec une catégorie float cashless",
+        text: isEn
+          ? "Resale tickets stay individual. Everything else (TGV, hotel, apartment, rental car, food, on-site cashless top-ups) goes into a shared pool with categories. Add a dedicated 'cashless float' line so the merch and bar rounds don't disappear into a giant 'misc' column."
+          : "Les billets de revente restent individuels. Le reste (TGV, hôtel, appartement, voiture, restos, rechargements cashless) va dans un pot commun avec catégories. Ajoutez une ligne 'float cashless' dédiée pour que le merch et les tournées au bar ne se perdent pas dans une colonne 'divers'.",
+        url: `${SITE_URL}/${locale}/features/budget`,
+      },
+      {
+        "@type": "HowToStep",
+        position: 4,
+        name: isEn ? "Plan the four days stage by stage" : "Planifier les quatre jours scène par scène",
+        text: isEn
+          ? "Six stages, 183 artists, clashes everywhere — share the schedule in advance so the group knows who is at Mainstage 1 for Iron Maiden vs who is staying at the Altar for Cult of Luna. Block water and food breaks into the timeline, not just the bands."
+          : "Six scènes, 183 artistes, des clashs partout — partagez la grille à l'avance pour savoir qui est à Mainstage 1 pour Iron Maiden vs qui reste à l'Altar pour Cult of Luna. Bloquez les pauses eau et nourriture dans la timeline, pas seulement les groupes.",
+      },
+    ],
+  };
+
+  return (
+    <>
+      <AuthorJsonLd />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(musicEventLd) }} />
+      <Nav navData={navData} navigationData={navigationData} />
+
+      <main className="min-h-screen bg-[#FFFBF5]">
+
+        {/* ━━━ HERO ━━━ */}
+        <section className="pt-[140px] lg:pt-[200px] pb-16 lg:pb-24 px-6 lg:px-12">
+          <div className="max-w-[900px] mx-auto">
+            <div className="hidden lg:block mb-8">
+              <Breadcrumb items={[
+                { label: isEn ? "Home" : "Accueil", href: `/${locale}` },
+                { label: isEn ? "Hellfest 2026 Trip Planner" : "Voyage Hellfest 2026" },
+              ]} />
+            </div>
+            <p className="font-nanum-pen text-[#F6391A] text-lg lg:text-xl mb-6">
+              {isEn ? "Festival guide & trip planner · Clisson 2026" : "Guide du festival & planificateur · Clisson 2026"}
+            </p>
+            <h1 className="text-[#001E13] text-[38px] lg:text-[72px] font-londrina-solid leading-[1.02] mb-6">
+              {isEn
+                ? "Hellfest 2026: Your Trip Planner to Clisson"
+                : "Hellfest 2026 : Le Guide Voyage à Clisson"}
+            </h1>
+            <p className="text-[#001E13]/70 text-lg lg:text-[22px] font-karla leading-[1.8] mb-6">
+              {isEn
+                ? <>18 to 21 June 2026, Val de Moine, Clisson. 183 artists across six stages, Iron Maiden running their 50-year anniversary tour, Bring Me The Horizon opening, Limp Bizkit and The Offspring closing the weekend. The festival is sold out — the trip is not. This is the complete guide to getting to Clisson, where to sleep, how the cashless works, and how to keep the crew aligned on budget and schedule across four very long days. If you&apos;re still picking your tools, see our <Link href={`/${locale}/blog/meilleures-applications-voyage-groupe`} className="text-[#F6391A] hover:underline font-semibold">comparison of group travel apps</Link>.</>
+                : <>Du 18 au 21 juin 2026, Val de Moine, Clisson. 183 artistes sur six scènes, Iron Maiden en pleine tournée des 50 ans, Bring Me The Horizon en ouverture, Limp Bizkit et The Offspring pour clôturer. Le festival est sold out — le voyage, lui, ne l&apos;est pas. Voici le guide complet pour rejoindre Clisson, où dormir, comment marche le cashless, et comment garder toute la bande alignée sur le budget et la grille pendant quatre jours intenses. Si vous hésitez encore entre les outils, jetez un œil à notre <Link href={`/${locale}/blog/meilleures-applications-voyage-groupe`} className="text-[#F6391A] hover:underline font-semibold">comparatif d&apos;applis de voyage en groupe</Link>.</>}
+            </p>
+            <p className="text-[#001E13]/50 text-sm font-karla mb-6">{isEn ? "9 min read" : "9 min de lecture"}</p>
+            <AuthorBio locale={locale} publishedDate="2026-05-13" modifiedDate="2026-05-13" />
+          </div>
+        </section>
+
+        {/* ━━━ KEY FACTS BOX ━━━ */}
+        <section className="pb-16 lg:pb-20 px-6 lg:px-12">
+          <div className="max-w-[1000px] mx-auto">
+            <div className="bg-white border border-[#001E13]/8 rounded-[24px] lg:rounded-[32px] p-6 lg:p-10">
+              <h2 className="text-[#001E13]/40 font-karla text-xs lg:text-sm uppercase tracking-[0.2em] mb-6">
+                {isEn ? "Festival facts" : "Les chiffres du festival"}
+              </h2>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-6 lg:gap-10">
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Dates" : "Dates"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">{isEn ? "18–21 Jun" : "18-21 juin"}</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">2026</p>
+                </div>
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Site" : "Site"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">Val de Moine</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">Clisson, FR</p>
+                </div>
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Stages" : "Scènes"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">6</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">{isEn ? "183 artists" : "183 artistes"}</p>
+                </div>
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Capacity" : "Capacité"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">~60k</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">{isEn ? "per day" : "par jour"}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ THE STAKES ━━━ */}
+        <section className="pb-16 lg:pb-24 px-6 lg:px-12">
+          <div className="max-w-[900px] mx-auto space-y-8">
+            <p className="text-[#001E13]/75 text-lg lg:text-[22px] font-karla leading-[1.8]">
+              {isEn
+                ? "A four-day pilgrimage to a wine-growing town of 7,000 people that turns into the loudest place in Europe. The headliners cover the full spectrum the festival is built on: a metalcore generation opener with Bring Me The Horizon, a heritage night with Iron Maiden on the road for their 50 Years tour, a nu-metal Saturday with Limp Bizkit, and a punk-rock Sunday closer with The Offspring. Underneath, 179 other bands across six stages, 85 of them at Hellfest for the first time. The festival is sold out — but the operation around it is what most fans will actually remember: the TGV from Montparnasse, the apartment shared with six mates in Nantes, the cashless wristband that runs out at midnight on the Saturday, the TER back to Clisson at 11am on Sunday before the Mainstage 1 closer."
+                : "Quatre jours de pèlerinage dans une ville viticole de 7 000 habitants qui devient l'endroit le plus bruyant d'Europe. Les têtes d'affiche couvrent tout le spectre du festival : ouverture metalcore avec Bring Me The Horizon, soirée patrimoine avec Iron Maiden en tournée des 50 ans, nu-metal le samedi avec Limp Bizkit, et clôture punk-rock le dimanche avec The Offspring. En dessous, 179 autres groupes sur six scènes, dont 85 pour la première fois au Hellfest. Le festival est sold out — mais ce que la plupart des fans retiendront, c'est l'opération autour : le TGV à Montparnasse, l'appartement partagé à six potes à Nantes, le bracelet cashless en rade à minuit le samedi, le TER pour Clisson à 11h le dimanche avant la clôture Mainstage 1."}
+            </p>
+            <p className="text-[#001E13] text-lg lg:text-[22px] font-karla font-bold leading-[1.8]">
+              {isEn
+                ? "WePlanify is the free shared command center for fans heading to Clisson — TGV, apartment, cashless float, four-day schedule and budget in one place, in English or French."
+                : "WePlanify, c'est le poste de commandement gratuit et partagé pour les fans qui descendent à Clisson — TGV, appartement, float cashless, grille des quatre jours et budget au même endroit, en français ou anglais."}
+            </p>
+          </div>
+        </section>
+
+        {/* ━━━ TABLE OF CONTENTS ━━━ */}
+        <section className="px-6 lg:px-12">
+          <div className="max-w-[900px] mx-auto">
+            <ArticleTOC
+              title={isEn ? "On this page" : "Sur cette page"}
+              items={[
+                { id: "the-lineup", label: isEn ? "The 2026 lineup" : "L'affiche 2026" },
+                { id: "tickets", label: isEn ? "Tickets & official resale" : "Billetterie & revente officielle" },
+                { id: "getting-there", label: isEn ? "Getting to Clisson" : "Rejoindre Clisson" },
+                { id: "sleeping", label: isEn ? "Where to sleep" : "Où dormir" },
+                { id: "cashless", label: isEn ? "Cashless & on-site practicalities" : "Cashless & pratique sur site" },
+                { id: "planning", label: isEn ? "Planning the trip with the crew" : "Organiser le voyage entre potes" },
+                { id: "budget", label: isEn ? "Budget tips" : "Astuces budget" },
+                { id: "faq", label: isEn ? "Frequently asked questions" : "Questions fréquentes" },
+              ]}
+            />
+          </div>
+        </section>
+
+        {/* ━━━ THE LINEUP ━━━ */}
+        <FadeIn>
+          <section id="the-lineup" className="bg-[#001E13] py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[1000px] mx-auto">
+              <h2 className="text-[#FFFBF5] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "The 2026 Lineup" : "L'Affiche 2026"}
+              </h2>
+              <p className="text-[#FFFBF5]/50 font-karla text-base lg:text-lg mb-14 max-w-[700px]">
+                {isEn
+                  ? "Four headline nights, six stages, 183 artists. The clashes you'll need to negotiate inside the group before you even buy the TGV ticket."
+                  : "Quatre soirées en tête d'affiche, six scènes, 183 artistes. Les clashs à négocier dans le groupe avant même de réserver le TGV."}
+              </p>
+
+              <div className="space-y-0">
+                {(isEn
+                  ? [
+                      { stop: "Thursday — Bring Me The Horizon", desc: "The opener is the modern-metal anchor of the weekend. BMTH on the Mainstage signals where the festival is going generationally — broader than the old underground core, still loud enough to satisfy it. Expect a high-production show and a much younger crowd up front than the rest of the weekend." },
+                      { stop: "Friday — Iron Maiden 'Run For Your Lives'", desc: "Maiden's 50-year anniversary tour stops at Clisson. The setlist on this run leans heavily on the first decade catalogue, which is exactly what most of the crowd has been waiting for since the announcement. Plan to be in the photo pit zone early — Friday is the night Mainstage 1 will be hardest to leave once you're in." },
+                      { stop: "Saturday — Limp Bizkit", desc: "The nu-metal comeback that nobody saw landing in 2026. Limp Bizkit on the Mainstage on a Saturday night is a nostalgia bomb for one half of the crowd and a curiosity show for the other. Either way, the singalongs travel further into the camping zones than the actual amps." },
+                      { stop: "Sunday — The Offspring", desc: "Closing the weekend on Mainstage 1, The Offspring brings the punk-rock catalog that ages stupidly well in a tired Sunday-night crowd. The slot is also the most painful clash window of the festival — A Perfect Circle, Behemoth and others fight for the same hour." },
+                      { stop: "Underneath the headliners", desc: "183 artists across 6 stages, 85 at Hellfest for the first time. Names to keep on your radar: A Perfect Circle, Breaking Benjamin, Volbeat, Behemoth, Cult of Luna, Amenra, Igorrr, Kadavar, Ultra Vomit. Share the full schedule inside the group early — clashes are constant and the call to skip the headliner for the Altar slot is the most divisive in any festival weekend." },
+                    ]
+                  : [
+                      { stop: "Jeudi — Bring Me The Horizon", desc: "L'ouverture, c'est l'ancrage metal moderne du week-end. BMTH en Mainstage indique où le festival va générationnellement — plus large que le noyau underground historique, encore assez bruyant pour ne pas le perdre. Attendez-vous à un show ultra-produit et à un public devant scène nettement plus jeune que le reste du week-end." },
+                      { stop: "Vendredi — Iron Maiden 'Run For Your Lives'", desc: "La tournée des 50 ans de Maiden passe par Clisson. La setlist de ce run pioche très largement dans la première décennie du groupe, ce que la moitié de la foule attendait depuis l'annonce. Visez le pit photo tôt — vendredi sera la soirée où Mainstage 1 sera la plus difficile à quitter une fois rentrés." },
+                      { stop: "Samedi — Limp Bizkit", desc: "Le retour nu-metal que personne n'avait vu venir en 2026. Limp Bizkit en Mainstage un samedi soir, c'est une bombe nostalgie pour la moitié du public et une curiosité pour l'autre. Dans tous les cas, les refrains portent jusqu'aux zones de camping bien au-delà des enceintes." },
+                      { stop: "Dimanche — The Offspring", desc: "Clôture Mainstage 1 avec The Offspring : un catalogue punk-rock qui vieillit incroyablement bien sur un public de fin de festival. Le créneau, c'est aussi le clash le plus douloureux du week-end — A Perfect Circle, Behemoth et d'autres se battent pour la même heure." },
+                      { stop: "Sous les têtes d'affiche", desc: "183 artistes sur 6 scènes, dont 85 au Hellfest pour la première fois. Noms à garder dans le radar : A Perfect Circle, Breaking Benjamin, Volbeat, Behemoth, Cult of Luna, Amenra, Igorrr, Kadavar, Ultra Vomit. Partagez la grille complète tôt dans le groupe — les clashs sont permanents, et la décision de zapper la tête d'affiche pour un créneau Altar est la plus clivante de tout week-end festival." },
+                    ]
+                ).map((item, i) => (
+                  <div key={i} className="flex gap-6 lg:gap-8">
+                    <div className="flex flex-col items-center flex-shrink-0">
+                      <div className="w-4 h-4 bg-[#F6391A] rounded-full" />
+                      {i < 4 && <div className="w-0.5 flex-1 bg-[#FFFBF5]/10" />}
+                    </div>
+                    <div className="pb-12 lg:pb-16">
+                      <h3 className="text-[#FFFBF5] text-xl lg:text-2xl font-londrina-solid mb-2">{item.stop}</h3>
+                      <p className="text-[#FFFBF5]/55 text-sm lg:text-base font-karla leading-[1.8]">{item.desc}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ TICKETS & RESALE ━━━ */}
+        <section id="tickets" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24 bg-[#FFFBF5]">
+          <div className="max-w-[1000px] mx-auto">
+            <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+              {isEn ? "Tickets & Official Resale" : "Billetterie & Revente Officielle"}
+            </h2>
+            <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-10 max-w-[700px]">
+              {isEn
+                ? "Sold out everywhere — and the only path forward is one verified resale platform. Everything else is a counterfeit risk."
+                : "Sold out partout — et le seul chemin restant, c'est une seule plateforme de revente vérifiée. Tout le reste est un risque de faux billet."}
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Channel 1" : "Canal 1"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Official resale" : "Revente officielle"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "tickets.hellfest.fr is the only legitimate channel. Listings appear when other fans cancel — sometimes daily, sometimes only the week of. Check several times a day and have payment ready, listings disappear in minutes." : "tickets.hellfest.fr, c'est le seul canal légitime. Des annonces apparaissent quand des festivaliers annulent — parfois chaque jour, parfois seulement la semaine du festival. Refresh plusieurs fois par jour, paiement prêt, les billets partent en minutes."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Channel 2" : "Canal 2"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Daily passes (sold out)" : "Pass jour (sold out)"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "Single-day passes also sold out for 2026. They reappear sporadically on the official resale alongside the 4-day passes. If only one of you needs a single day, it's actually easier to find than a full pass." : "Les pass 1 jour aussi sont sold out pour 2026. Ils réapparaissent ponctuellement sur la revente officielle aux côtés des pass 4 jours. Si une seule personne du groupe a besoin d'une seule journée, c'est en pratique plus facile à trouver qu'un pass complet."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "What to avoid" : "À éviter"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Unofficial resale" : "Revente parallèle"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "Telegram groups, Facebook marketplace, Vinted, Leboncoin: counterfeit tickets are widely reported and won't pass the gate scan. The wristband is nominative — you can't legally transfer outside the official channel." : "Groupes Telegram, Marketplace Facebook, Vinted, Leboncoin : les faux billets sont massivement signalés et ne passent pas le scan d'entrée. Le bracelet est nominatif — vous ne pouvez pas transférer légalement en dehors du canal officiel."}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ GETTING THERE ━━━ */}
+        <FadeIn>
+          <section id="getting-there" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[1000px] mx-auto">
+              <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "Getting to Clisson" : "Rejoindre Clisson"}
+              </h2>
+              <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-12 max-w-[700px]">
+                {isEn
+                  ? "TGV to Nantes, TER to Clisson — the rail route is faster and cheaper than driving for almost every European starting point. The €5 'Live' ticket inside the region is the best deal in the entire trip."
+                  : "TGV jusqu'à Nantes, TER jusqu'à Clisson — l'itinéraire ferroviaire est plus rapide et moins cher que la voiture pour presque tous les points de départ européens. Le billet 'Live' à 5 € dans la région est la meilleure affaire de tout le voyage."}
+              </p>
+
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-10">
+                <div className="bg-[#001E13] rounded-[24px] p-8 lg:p-10">
+                  <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "From Paris" : "Depuis Paris"}</p>
+                  <h3 className="text-[#FFFBF5] text-3xl lg:text-4xl font-londrina-solid mb-6">Paris → Nantes → Clisson</h3>
+                  <ul className="space-y-3 text-[#FFFBF5]/70 font-karla text-sm lg:text-base leading-[1.7]">
+                    <li>{isEn ? "→ TGV INOUI or Ouigo from Paris-Montparnasse" : "→ TGV INOUI ou Ouigo depuis Paris-Montparnasse"}</li>
+                    <li>{isEn ? "→ 2h00 to 2h26 to Nantes" : "→ 2h00 à 2h26 jusqu'à Nantes"}</li>
+                    <li>{isEn ? "→ From ~€16 (Ouigo, booked early) to €40-90 last-minute" : "→ À partir de ~16 € (Ouigo réservé tôt) à 40-90 € de dernière minute"}</li>
+                    <li>{isEn ? "→ TER Nantes–Clisson: hourly, 16-30 min, €5 with the 'Live' ticket" : "→ TER Nantes-Clisson : toutes les heures, 16-30 min, 5 € avec le billet 'Live'"}</li>
+                    <li>{isEn ? "→ Clisson station to site: 20 min walk or short paid shuttle" : "→ Gare de Clisson au site : 20 min à pied ou navette payante"}</li>
+                  </ul>
+                </div>
+
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-8 lg:p-10">
+                  <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "From Lille, Brussels, by car or by plane" : "Depuis Lille, Bruxelles, en voiture ou en avion"}</p>
+                  <h3 className="text-[#001E13] text-3xl lg:text-4xl font-londrina-solid mb-6">{isEn ? "Other routes" : "Autres routes"}</h3>
+                  <ul className="space-y-3 text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.7]">
+                    <li>{isEn ? "→ Lille → Nantes direct TGV in ~4h, from ~€37" : "→ Lille → Nantes TGV direct en ~4h, à partir de ~37 €"}</li>
+                    <li>{isEn ? "→ Brussels → Nantes one direct TGV/day, ~4h47, from ~€20" : "→ Bruxelles → Nantes un TGV direct/jour, ~4h47, à partir de ~20 €"}</li>
+                    <li>{isEn ? "→ Car: free East/West parkings with free shuttles to the site" : "→ Voiture : parkings gratuits Est/Ouest avec navettes gratuites vers le site"}</li>
+                    <li>{isEn ? "→ Airport: Nantes-Atlantique (NTE), festival shuttle available from the airport" : "→ Avion : Nantes-Atlantique (NTE), navette festival depuis l'aéroport"}</li>
+                    <li>{isEn ? "→ Driving from Paris: ~4h30 without traffic, more on Wednesday and Sunday" : "→ Voiture depuis Paris : ~4h30 sans bouchon, plus le mercredi et le dimanche"}</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ WHERE TO SLEEP ━━━ */}
+        <section id="sleeping" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24 bg-[#FFFBF5]">
+          <div className="max-w-[1000px] mx-auto">
+            <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+              {isEn ? "Where to Sleep" : "Où Dormir"}
+            </h2>
+            <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-10 max-w-[700px]">
+              {isEn
+                ? "Three honest options. Camping is the experience; Nantes apartments are the budget play; premium Easy Camp is gone for 2026."
+                : "Trois options honnêtes. Le camping, c'est l'expérience ; l'appartement à Nantes, c'est le bon plan budget ; l'Easy Camp premium est parti pour 2026."}
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Option 1" : "Option 1"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Classic camping" : "Camping classique"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "Included in the 4-day pass. Basic, loud, communal — the actual heart of the Hellfest experience. Bring earplugs if you ever want to sleep before 4am. Pack a tent that survives wind, not just sun." : "Inclus dans le pass 4 jours. Basique, bruyant, communautaire — le cœur réel de l'expérience Hellfest. Prévoyez des bouchons d'oreilles si vous comptez dormir avant 4h. Choisissez une tente qui tient le vent, pas seulement le soleil."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Option 2" : "Option 2"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Nantes apartment" : "Appartement à Nantes"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "30 km away, 30-45 min by TER or car. A 3-4 bedroom apartment split between 4-6 friends typically beats hotel rooms by 30-50%. Trade-off: you lose the camping vibe but gain showers, a real bed and a way to recover." : "À 30 km, 30-45 min en TER ou en voiture. Un appartement 3-4 chambres partagé à 4-6 bat souvent les chambres d'hôtel de 30-50 %. Trade-off : on perd l'ambiance camping mais on gagne douche, vrai lit et capacité de récupération."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Option 3" : "Option 3"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Nantes hotels" : "Hôtels à Nantes"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "Average around €130-180/night on festival weekend, 20-60% above normal rates. Book early near a tram line to the station — the morning TER to Clisson fills up fast and you don't want a 6am taxi battle." : "Autour de 130-180 €/nuit sur le week-end festival, +20 à 60 % par rapport au tarif normal. Réservez tôt près d'une ligne de tram menant à la gare — le TER du matin pour Clisson se remplit vite et personne ne veut se battre pour un taxi à 6h."}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ CASHLESS & PRACTICALITIES ━━━ */}
+        <FadeIn>
+          <section id="cashless" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[1000px] mx-auto">
+              <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "Cashless & On-Site Practicalities" : "Cashless & Pratique sur Site"}
+              </h2>
+              <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-12 max-w-[700px]">
+                {isEn
+                  ? "The site is 100% cashless via the festival wristband. Plan the float in advance — the on-site top-up queues will eat your Iron Maiden time."
+                  : "Le site est 100 % cashless via le bracelet. Anticipez le float — les files de recharge sur place mangeront votre créneau Iron Maiden."}
+              </p>
+
+              <div className="space-y-6">
+                <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6 lg:p-8">
+                  <h3 className="text-[#001E13] font-londrina-solid text-xl lg:text-2xl mb-3">{isEn ? "How the wristband works" : "Comment marche le bracelet"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.8]">
+                    {isEn
+                      ? "First activation costs €1.50. Top up online at cashless.hellfest.fr or via the Hellfest app — no fee on subsequent top-ups. Cash is accepted only at on-site cashless banks, never at bars or food stands. Unspent balance is refundable through the official portal within the post-festival window."
+                      : "Première activation à 1,50 €. Rechargez en ligne sur cashless.hellfest.fr ou via l'app Hellfest — pas de frais sur les rechargements suivants. Le cash n'est accepté qu'aux banques cashless sur site, jamais aux bars ni aux stands de bouffe. Le solde non utilisé est remboursable via le portail officiel dans la fenêtre annoncée après le festival."}
+                  </p>
+                </div>
+                <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6 lg:p-8">
+                  <h3 className="text-[#001E13] font-londrina-solid text-xl lg:text-2xl mb-3">{isEn ? "What slows everyone down" : "Ce qui ralentit tout le monde"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.8]">
+                    {isEn
+                      ? "Phone charging stations cap at 30 minutes and the queues are constant — bring a 20,000mAh power bank per group, charged twice. ATMs are scarce (Hell City Square and Clisson supermarket only) and slow. Mobile network saturates with 60k+ attendees: agree on a meeting point per stage in advance because group chats will not deliver in real time."
+                      : "Les stations de charge téléphone sont plafonnées à 30 minutes, files permanentes — prévoyez une batterie externe 20 000 mAh par groupe, chargée deux fois. Les DAB sont rares (uniquement Hell City Square et le supermarché de Clisson) et lents. Le réseau mobile sature avec 60 000 personnes : convenez d'un point de rendez-vous par scène à l'avance, les messages de groupe ne passent pas en temps réel."}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ PLANNING THE TRIP ━━━ */}
+        <section id="planning" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24 bg-[#FFFBF5]">
+          <div className="max-w-[900px] mx-auto space-y-8">
+            <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08]">
+              {isEn ? "Planning the Trip with the Crew" : "Organiser le Voyage entre Potes"}
+            </h2>
+            <p className="text-[#001E13]/75 text-lg lg:text-[22px] font-karla leading-[1.8]">
+              {isEn
+                ? <>The four-day festival rhythm makes group coordination harder than a weekend city break. People arrive on different days, leave at different times, and some lose their phone by Saturday. The crew aligns when the schedule, the budget and the meeting points live in one shared place. Run a quick <Link href={`/${locale}/features/polls`} className="text-[#F6391A] hover:underline font-semibold">group poll</Link> early to lock who is camping vs hotel-ing, who lands when, and who is taking the rental car. The poll is the smallest piece of work that prevents 80% of the festival arguments.</>
+                : <>Le rythme quatre jours rend la coordination de groupe bien plus dure qu&apos;un city break de week-end. Tout le monde arrive à des jours différents, repart à des heures différentes, et certains ont perdu leur téléphone le samedi. La bande s&apos;aligne quand la grille, le budget et les points de rendez-vous vivent au même endroit partagé. Lancez un <Link href={`/${locale}/features/polls`} className="text-[#F6391A] hover:underline font-semibold">sondage de groupe</Link> tôt pour caler qui campe vs qui prend l&apos;hôtel, qui arrive quand, qui prend la voiture. Le sondage, c&apos;est le plus petit travail qui évite 80 % des engueulades du festival.</>}
+            </p>
+            <p className="text-[#001E13]/75 text-lg lg:text-[22px] font-karla leading-[1.8]">
+              {isEn
+                ? <>The four-day <Link href={`/${locale}/features/itinerary`} className="text-[#F6391A] hover:underline font-semibold">shared itinerary</Link> is where the band clashes live. Pin the must-sees (Iron Maiden Friday night, Limp Bizkit Saturday) and let the group fork on the others — nobody should feel guilty for ducking out of the headliner to catch Cult of Luna at the Altar. The same itinerary doubles as the meeting-point map: stage entrance, food stall, camping pole.</>
+                : <>L&apos;<Link href={`/${locale}/features/itinerary`} className="text-[#F6391A] hover:underline font-semibold">itinéraire partagé</Link> sur les quatre jours, c&apos;est là que vivent les clashs entre groupes. Épinglez les indispensables (Iron Maiden vendredi soir, Limp Bizkit samedi) et laissez le groupe se diviser sur le reste — personne ne doit culpabiliser de zapper la tête d&apos;affiche pour aller voir Cult of Luna à l&apos;Altar. Le même itinéraire fait office de carte des points de rendez-vous : entrée de scène, stand bouffe, mât du camping.</>}
+            </p>
+          </div>
+        </section>
+
+        {/* ━━━ BUDGET TIPS ━━━ */}
+        <FadeIn>
+          <section id="budget" className="bg-[#001E13] py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[900px] mx-auto space-y-8">
+              <h2 className="text-[#FFFBF5] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "Budget Tips" : "Astuces Budget"}
+              </h2>
+              <p className="text-[#FFFBF5]/65 text-lg lg:text-[22px] font-karla leading-[1.8]">
+                {isEn
+                  ? <>Resale tickets are bought individually and stay individual — keep them out of the shared pool entirely. The shared pool is for TGV, accommodation, rental car, restaurants in Nantes before and after, and the on-site cashless float. Set up a <Link href={`/${locale}/features/budget`} className="text-[#EEF899] hover:underline font-semibold">shared budget tracker</Link> with one category per cost type, and add an explicit &apos;cashless float&apos; line so the beer rounds and merch don&apos;t disappear into a generic &apos;misc&apos; column.</>
+                  : <>Les billets de revente sont achetés individuellement et restent individuels — gardez-les hors du pot commun. Le pot commun, c&apos;est pour le TGV, l&apos;hébergement, la voiture de location, les restos à Nantes avant et après, et le float cashless sur place. Mettez en place un <Link href={`/${locale}/features/budget`} className="text-[#EEF899] hover:underline font-semibold">suivi de budget partagé</Link> avec une catégorie par type de dépense, et ajoutez une ligne explicite « float cashless » pour que les tournées de bière et le merch ne se perdent pas dans une colonne « divers ».</>}
+              </p>
+              <p className="text-[#FFFBF5]/65 text-lg lg:text-[22px] font-karla leading-[1.8]">
+                {isEn
+                  ? "TGV prices have already moved. Paris–Nantes Ouigo at €16 in winter now sits around €40-70 on the Wed/Thu departures and €60-90 on the Sun/Mon returns. Two saves to know: very early morning departures (06:30-07:30) are still the cheapest slot, and booking the full crew on the same train shaves both cost and stress at arrival in Nantes."
+                  : "Les prix du TGV ont déjà bougé. Le Paris-Nantes Ouigo à 16 € en hiver tourne maintenant autour de 40-70 € sur les départs mer/jeu et 60-90 € sur les retours dim/lun. Deux astuces : les départs très matinaux (6h30-7h30) restent le créneau le moins cher, et réserver toute la bande sur le même train fait économiser à la fois en argent et en stress à l'arrivée à Nantes."}
+              </p>
+              <p className="text-[#FFFBF5]/65 text-lg lg:text-[22px] font-karla leading-[1.8]">
+                {isEn
+                  ? "On-site cashless is the silent budget killer. Beer rounds, food, merch — a typical Hellfest weekend ends around €150-200 per person on the wristband even on a moderate run. Top up €50 less than you think you need on day one: an extra reload mid-festival takes 10 minutes, but a €200 surprise refund six weeks later is just lost money during the weekend."
+                  : "Le cashless sur place, c'est le tueur silencieux du budget. Tournées, bouffe, merch — un week-end Hellfest moyen sort à 150-200 € par personne sur le bracelet même sur un rythme tranquille. Rechargez 50 € de moins que ce que vous estimez nécessaire le premier jour : un rechargement à mi-parcours prend 10 minutes, mais une surprise de 200 € de remboursement six semaines plus tard, c'est juste de l'argent perdu pendant le week-end."}
+              </p>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ FAQ ━━━ */}
+        <section id="faq" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+          <div className="max-w-[800px] mx-auto">
+            <h2 className="text-3xl lg:text-5xl font-londrina-solid text-[#001E13] mb-10 text-center">
+              {isEn ? "Frequently Asked Questions" : "Questions Fréquemment Posées"}
+            </h2>
+            <div className="space-y-6">
+              {faqItems.map((item, i) => (
+                <details key={i} className="group border-b border-[#001E13]/10 pb-5">
+                  <summary className="flex items-start justify-between cursor-pointer list-none font-karla font-semibold text-[#001E13] text-base lg:text-lg">
+                    <span className="pr-4">{item.q}</span>
+                    <span className="text-[#F6391A] text-xl leading-none mt-0.5 group-open:rotate-45 transition-transform">+</span>
+                  </summary>
+                  <p className="mt-3 text-[#001E13]/70 text-sm lg:text-base font-karla leading-relaxed">{item.a}</p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ DISCOVER MORE ━━━ */}
+        <section className="py-12 lg:py-16 px-6 lg:px-12 bg-[#FFFBF5]">
+          <div className="max-w-[1200px] mx-auto">
+            <h2 className="text-2xl lg:text-4xl font-londrina-solid text-[#001E13] text-center mb-10">{isEn ? "Discover More" : "Découvrir aussi"}</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              <Link href={`/${locale}/champions-league-final-2026-psg-arsenal`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Champions League Final" : "Finale Ligue des Champions"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "PSG vs Arsenal in Budapest, the complete guide." : "PSG vs Arsenal à Budapest, le guide complet."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read more →" : "En savoir plus →"}</span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/world-cup-2026-trip-planner`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "World Cup 2026 Trip Planner" : "Planificateur Coupe du Monde 2026"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "Follow your team across the USA, Canada and Mexico." : "Suivez votre équipe à travers USA, Canada et Mexique."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read more →" : "En savoir plus →"}</span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/trip-with-friends`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Trip with Friends" : "Voyage entre Amis"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "Plan any group trip effortlessly." : "Organisez n'importe quel voyage de groupe."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read more →" : "En savoir plus →"}</span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/guides/plan-group-trip`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Group Trip Guide" : "Guide Voyage de Groupe"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "The complete step-by-step guide." : "Le guide complet étape par étape."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read the guide →" : "Lire le guide →"}</span>
+                </div>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ CTA ━━━ */}
+        <section className="py-16 lg:py-24 px-6 lg:px-12">
+          <div className="max-w-[1200px] mx-auto">
+            <div className="bg-gradient-to-br from-[#F6391A] to-[#d42d10] rounded-[24px] lg:rounded-[40px] p-8 lg:p-16 text-center">
+              <h2 className="text-3xl lg:text-5xl font-londrina-solid text-[#FFFBF5] mb-4">
+                {isEn ? "Build Your Hellfest Trip" : "Construisez Votre Voyage Hellfest"}
+              </h2>
+              <p className="text-[#FFFBF5]/80 font-karla text-base lg:text-lg max-w-2xl mx-auto mb-8 leading-relaxed">
+                {isEn ? "TGV, apartment, cashless float, four-day schedule, shared budget — one plan, your whole crew on the same page." : "TGV, appartement, float cashless, grille des quatre jours, budget partagé — un seul plan, toute votre bande alignée."}
+              </p>
+              <div className="flex justify-center">
+                <Link href={`https://app.weplanify.com/${locale}/register?utm_source=landing&utm_campaign=hellfest-2026&template=hellfest-2026`}>
+                  <PulsatingButton className="font-karla font-bold">{isEn ? "Start planning" : "Commencer"}</PulsatingButton>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+      </main>
+      <Footer footerData={footerData} />
+    </>
+  );
+}

--- a/src/app/[locale]/solar-eclipse-2026-trip-planner/page.tsx
+++ b/src/app/[locale]/solar-eclipse-2026-trip-planner/page.tsx
@@ -1,0 +1,606 @@
+import { Metadata } from "next";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { sanityFetch } from "@/sanity/lib/fetch";
+import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
+import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
+import { PulsatingButton } from "@/components/magicui/pulsating-button";
+import Link from "next/link";
+import Breadcrumb from "@/components/Breadcrumb";
+import ArticleTOC from "@/components/ArticleTOC";
+import { setRequestLocale } from "next-intl/server";
+import { generateMetadataFromSanity } from "@/lib/metadata";
+import { routing } from "@/i18n/routing";
+import FadeIn from "@/components/FadeIn";
+import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
+
+type Props = { params: Promise<{ locale: string }> };
+const SITE_URL = "https://www.weplanify.com";
+const PATHNAME = "/solar-eclipse-2026-trip-planner";
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const metadata = await generateMetadataFromSanity(locale, PATHNAME);
+  const isEn = locale === "en";
+  const title = isEn
+    ? "Total Solar Eclipse 12 August 2026: Trip Planner for Iceland & Spain | WePlanify"
+    : "Éclipse Solaire Totale du 12 août 2026 : Guide Voyage Islande & Espagne | WePlanify";
+  const description = isEn
+    ? "Everything for the 12 August 2026 total solar eclipse: path of totality across Iceland and northern Spain, when and where the totality is longest, ISO 12312-2 glasses, cruise options, and how to plan the trip from France with a group."
+    : "Tout sur l'éclipse solaire totale du 12 août 2026 : trajectoire de la totalité en Islande et dans le nord de l'Espagne, où la totalité est la plus longue, lunettes ISO 12312-2, croisières, et comment organiser le voyage depuis la France à plusieurs.";
+  const currentUrl = `${SITE_URL}/${locale}${PATHNAME}`;
+  return {
+    ...metadata, title, description,
+    authors: [{ name: "Alex Martin" }],
+    openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl },
+    twitter: { ...metadata.twitter, title, description },
+    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+  };
+}
+
+export default async function SolarEclipse2026Page({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const isEn = locale === "en";
+
+  const [navData, navigationData, footerData]: [NavType, Navigation | null, FooterType | null] =
+    await Promise.all([
+      sanityFetch<NavType>({ query: navQuery, params: { locale }, tags: ["nav"] }),
+      sanityFetch<Navigation>({ query: navigationQuery, params: { locale }, tags: ["navigation"] }),
+      sanityFetch<FooterType>({ query: footerQuery, params: { locale }, tags: ["footer"] }),
+    ]);
+
+  const breadcrumbLd = {
+    "@context": "https://schema.org", "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: isEn ? "Home" : "Accueil", item: `${SITE_URL}/${locale}` },
+      { "@type": "ListItem", position: 2, name: isEn ? "Solar Eclipse 2026 Trip Planner" : "Voyage Éclipse 2026", item: `${SITE_URL}/${locale}${PATHNAME}` },
+    ],
+  };
+
+  const articleLd = {
+    "@context": "https://schema.org", "@type": "Article",
+    headline: isEn ? "Total Solar Eclipse 12 August 2026: Trip Planner for Iceland & Spain" : "Éclipse Solaire Totale du 12 août 2026 : Guide Voyage Islande & Espagne",
+    author: { "@type": "Person", name: "Alex Martin", jobTitle: "Travel Editor" },
+    publisher: { "@type": "Organization", name: "WePlanify", url: SITE_URL },
+    datePublished: "2026-05-13", dateModified: "2026-05-13",
+    mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}/${locale}${PATHNAME}` },
+  };
+
+  const eventLd = {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    name: isEn ? "Total Solar Eclipse of 12 August 2026" : "Éclipse Solaire Totale du 12 août 2026",
+    description: isEn
+      ? "Total solar eclipse on Wednesday 12 August 2026. Path of totality crosses eastern Greenland, western Iceland and northern Spain. Maximum totality 2 minutes 18 seconds off the Icelandic coast. First total solar eclipse visible from mainland Europe since 11 August 1999."
+      : "Éclipse solaire totale le mercredi 12 août 2026. La trajectoire de la totalité traverse l'est du Groenland, l'ouest de l'Islande et le nord de l'Espagne. Totalité maximale de 2 minutes 18 secondes au large de la côte islandaise. Première éclipse totale visible depuis l'Europe continentale depuis le 11 août 1999.",
+    image: [`${SITE_URL}/header-bg.webp`],
+    startDate: "2026-08-12T17:43:00+00:00",
+    endDate: "2026-08-12T18:35:00+00:00",
+    eventStatus: "https://schema.org/EventScheduled",
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    organizer: { "@type": "Organization", name: "NASA", url: "https://eclipse.gsfc.nasa.gov/" },
+    location: [
+      { "@type": "Place", name: "Iceland (Westfjords, Snæfellsnes, Reykjavík)", address: { "@type": "PostalAddress", addressCountry: "IS" } },
+      { "@type": "Place", name: "Spain (Galicia, Asturias, Castilla y León, Aragón, Valencia, Balearic Islands)", address: { "@type": "PostalAddress", addressCountry: "ES" } },
+    ],
+  };
+
+  const faqItems = isEn
+    ? [
+        { q: "When and where can I see the 12 August 2026 total solar eclipse?", a: "Wednesday 12 August 2026. The path of totality crosses eastern Greenland, western Iceland (including the Westfjords, Snæfellsnes peninsula and Reykjavík) and a wide band across northern Spain (Galicia, Asturias, Cantabria, Castilla y León, the Ebro Valley, Valencia and Mallorca). Maximum totality is 2 minutes 18 seconds — but that maximum is over open ocean ~45 km west of Látrabjarg, Iceland. Inhabited locations get shorter totality: Reykjavík ~1 minute, Zaragoza ~1 min 25 s, Palma de Mallorca ~1 min 36 s, Bilbao ~30 seconds. Madrid and Barcelona are NOT in totality." },
+        { q: "Will France see the total eclipse?", a: "No. Mainland France only sees a partial eclipse — but it's deep. Paris reaches 92.2% obscuration, Marseille and Nice around 95%, and Biarritz, the closest French city to the path, gets up to 99.5%. The partial phase runs from ~19:30 to ~20:30 Paris time. Without totality you never get the corona, the darkness or the safe naked-eye window — and the sun stays dangerous to look at the entire time. To see the total eclipse you have to cross into Spain or fly to Iceland." },
+        { q: "Iceland or Spain — which is the better trip?", a: "Statistically, inland northern Spain (Ebro Valley, Huesca, Zaragoza) has the best August cloud-cover odds along the entire path — roughly 35% chance of clouds in the right zones. Iceland averages closer to 70-85% cloud cover even in August. The Spanish trade-off: the sun is very low (4-11° above the horizon — only ~1 hour before sunset), so you need a clear western view (the sea, or a plain, never a city street). Iceland's trade-off: cloudier and more expensive, but the sun is higher (~24° in Reykjavík) and the totality experience is more isolated and dramatic." },
+        { q: "What about an eclipse cruise?", a: "Several cruise lines have positioned ships in the western Mediterranean and around Mallorca to give passengers the freedom to move under clearer sky on the day. Costa Cruises runs a 7-night eclipse cruise from ~€450 per person. The French line CFC has positioned its 'Renaissance' between the Balearics and Sardinia, 6 nights from Marseille, from around €1,279. Princess Cruises and Holland America also have eclipse-themed itineraries. The advantage is meteorological flexibility; the downside is that a slow-moving ship can't always escape a cloud bank in time." },
+        { q: "What kind of glasses do I need?", a: "ISO 12312-2:2015 certified solar viewing glasses, with the CE marking. Regular sunglasses are not safe — even the darkest ones let through enough infrared and visible light to cause solar retinopathy. ISO 12312-2 glasses are sold at French pharmacies (advance sales typically open in June), Bresser.fr, Astronome.fr, Stelvision (Soleils Noirs), and through MyEclipseGlasses on Amazon. Buy one pair per person, check the date stamp (glasses older than 3 years should be replaced) and store them flat. During totality only — and only if you're actually IN totality — you can look with the naked eye." },
+        { q: "Have hotels already sold out?", a: "Many of the high-leverage spots have, yes. Hotels.com reported a 445% surge in searches for eclipse destinations. Palencia rooms have been listed up to €1,095 per night (about 10× normal). Mallorca rates have roughly tripled for the night of 11-12 August. The Reykjavik Edition has been quoted at $4,399/night. Tour operators booked Zaragoza, Valencia and Bilbao 18+ months in advance. If you're starting now, look slightly outside the headline cities — smaller towns inside the path are still bookable." },
+        { q: "How do you organise an eclipse trip with a group of friends?", a: "Eclipses are short — 30 seconds to 2 minutes depending on where you are — so the logistics matter more than for any normal trip. Decide as a group whether you optimise for cloud odds (Ebro Valley, inland Spain), totality duration (Mallorca), or experience (Iceland). Lock the location, the transport (flight to Bilbao or Reykjavík, or train + drive), and the exact observation spot before booking accommodation. WePlanify keeps the destination poll, the budget and the timeline for the day itself all in one shared place." },
+      ]
+    : [
+        { q: "Quand et où peut-on voir l'éclipse totale du 12 août 2026 ?", a: "Mercredi 12 août 2026. La trajectoire de la totalité traverse l'est du Groenland, l'ouest de l'Islande (dont les Westfjords, la péninsule de Snæfellsnes et Reykjavík) et une large bande dans le nord de l'Espagne (Galice, Asturies, Cantabrie, Castille-et-León, vallée de l'Èbre, Valence et Majorque). Totalité maximale de 2 minutes 18 secondes — mais ce maximum est en pleine mer à ~45 km à l'ouest de Látrabjarg, en Islande. Les lieux habités ont une totalité plus courte : Reykjavík ~1 min, Saragosse ~1 min 25 s, Palma de Majorque ~1 min 36 s, Bilbao ~30 secondes. Madrid et Barcelone NE SONT PAS dans la totalité." },
+        { q: "La France verra-t-elle la totalité ?", a: "Non. La France métropolitaine ne voit qu'une éclipse partielle — mais profonde. Paris atteint 92,2 % d'obscurcissement, Marseille et Nice environ 95 %, et Biarritz, la ville française la plus proche de la trajectoire, monte à 99,5 %. La phase partielle se déroule de ~19h30 à ~20h30 heure de Paris. Sans totalité on n'a jamais la couronne, l'obscurité ni la fenêtre où l'œil nu est sans danger — et le soleil reste dangereux à regarder pendant toute la durée. Pour voir l'éclipse totale, il faut passer la frontière espagnole ou aller en Islande." },
+        { q: "Islande ou Espagne — quel est le meilleur voyage ?", a: "Statistiquement, l'intérieur du nord de l'Espagne (vallée de l'Èbre, Huesca, Saragosse) a les meilleures probabilités de ciel dégagé en août sur toute la trajectoire — environ 35 % de risque de nuages dans les bonnes zones. L'Islande tourne plutôt à 70-85 % de couverture nuageuse même en août. Le trade-off espagnol : le soleil est très bas (4-11° au-dessus de l'horizon — environ 1 h avant le coucher), il faut un horizon ouest dégagé (la mer, une plaine, jamais une rue urbaine). Trade-off islandais : plus nuageux et plus cher, mais le soleil est plus haut (~24° à Reykjavík) et l'expérience de la totalité est plus isolée et plus spectaculaire." },
+        { q: "Et la croisière éclipse, ça vaut le coup ?", a: "Plusieurs compagnies ont positionné des navires en Méditerranée occidentale et autour de Majorque pour laisser aux passagers la liberté de bouger sous un ciel plus clair le jour J. Costa Croisières propose une croisière 7 nuits dès ~450 € par personne. La française CFC positionne son « Renaissance » entre Baléares et Sardaigne, 6 nuits depuis Marseille, dès 1 279 €. Princess Cruises et Holland America ont aussi des itinéraires éclipse. L'avantage, c'est la flexibilité météo ; l'inconvénient, c'est qu'un navire lent ne peut pas toujours échapper à un banc de nuages à temps." },
+        { q: "Quelles lunettes utiliser ?", a: "Des lunettes éclipse certifiées ISO 12312-2:2015, avec marquage CE. Les lunettes de soleil ordinaires sont dangereuses — même les plus foncées laissent passer suffisamment d'infrarouge et de lumière visible pour causer une rétinopathie solaire. On en trouve en pharmacie en France (préventes habituellement ouvertes en juin), sur Bresser.fr, Astronome.fr, Stelvision (Soleils Noirs), ou via MyEclipseGlasses sur Amazon. Prévoyez une paire par personne, vérifiez la date imprimée (à remplacer après 3 ans) et conservez-les à plat. Pendant la totalité uniquement — et uniquement si vous êtes physiquement DANS la totalité — vous pouvez regarder à l'œil nu." },
+        { q: "Les hôtels sont-ils déjà sold out ?", a: "Beaucoup de spots à fort effet de levier, oui. Hotels.com a rapporté +445 % de recherches sur les destinations éclipse. Des chambres à Palencia ont été affichées jusqu'à 1 095 € la nuit (environ 10× le tarif normal). Les tarifs majorquins ont roughly triplé pour la nuit du 11-12 août. Le Reykjavik Edition a été annoncé à 4 399 $/nuit. Les tour-opérateurs ont bloqué Saragosse, Valence et Bilbao 18 mois en amont. Si vous démarrez maintenant, sortez légèrement des villes vedettes — de plus petites villes dans la bande restent réservables." },
+        { q: "Comment organiser un voyage éclipse à plusieurs ?", a: "Les éclipses sont courtes — 30 secondes à 2 minutes selon le lieu — donc la logistique pèse plus que pour n'importe quel voyage normal. Décidez en groupe si vous optimisez pour la météo (vallée de l'Èbre, Espagne intérieure), pour la durée (Majorque), ou pour l'expérience (Islande). Verrouillez le lieu, le transport (vol vers Bilbao ou Reykjavík, ou train + voiture) et le point d'observation exact avant de réserver l'hébergement. WePlanify garde le sondage destination, le budget et la timeline du jour J au même endroit partagé." },
+      ];
+
+  const faqLd = {
+    "@context": "https://schema.org", "@type": "FAQPage",
+    mainEntity: faqItems.map((item) => ({ "@type": "Question", name: item.q, acceptedAnswer: { "@type": "Answer", text: item.a } })),
+  };
+
+  const howToLd = {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: isEn ? "How to plan a total solar eclipse 2026 trip" : "Comment organiser un voyage pour l'éclipse totale 2026",
+    description: isEn
+      ? "Three months out, here is how to lock the trip: pick your location (cloud odds vs duration vs experience), book travel and accommodation before the next price hike, get ISO 12312-2 glasses, and plan the actual observation hour."
+      : "À trois mois, voici comment verrouiller le voyage : choisir le lieu (météo vs durée vs expérience), réserver transport et hébergement avant la prochaine hausse, acheter des lunettes ISO 12312-2, et planifier l'heure d'observation.",
+    totalTime: "PT60M",
+    step: [
+      {
+        "@type": "HowToStep",
+        position: 1,
+        name: isEn ? "Pick your location — and align the group on it" : "Choisir le lieu — et aligner le groupe dessus",
+        text: isEn
+          ? "The three honest options are inland Spain (Ebro Valley, ~35% cloud risk, short totality), Mallorca (longer totality but sun very low, needs sea horizon), and Iceland (high cloud risk but dramatic experience). Run a group poll before booking anything — the trade-offs split families in real life."
+          : "Les trois vraies options sont l'Espagne intérieure (vallée de l'Èbre, ~35 % de risque de nuages, totalité courte), Majorque (totalité plus longue mais soleil très bas, horizon mer indispensable), et l'Islande (forte couverture nuageuse mais expérience spectaculaire). Lancez un sondage de groupe avant de réserver — les trade-offs divisent vraiment les familles.",
+        url: `${SITE_URL}/${locale}/features/polls`,
+      },
+      {
+        "@type": "HowToStep",
+        position: 2,
+        name: isEn ? "Book transport and accommodation before the next hike" : "Réserver transport et hébergement avant la prochaine hausse",
+        text: isEn
+          ? "Paris-Reykjavík takes ~3h30 with Icelandair or easyJet from CDG. Paris-Bilbao is a short flight or a long train (14-15h via Hendaye). Accommodation in headline cities (Zaragoza, Reykjavík, Palma) is largely gone — look at smaller towns inside the path, or a serviced apartment for the group."
+          : "Paris-Reykjavík fait ~3h30 avec Icelandair ou easyJet depuis CDG. Paris-Bilbao, c'est un court vol ou un long train (14-15h via Hendaye). L'hébergement dans les villes vedettes (Saragosse, Reykjavík, Palma) est largement parti — regardez les plus petites villes de la bande, ou un appartement partagé pour le groupe.",
+        url: `${SITE_URL}/${locale}/features/itinerary`,
+      },
+      {
+        "@type": "HowToStep",
+        position: 3,
+        name: isEn ? "Order ISO 12312-2 glasses and the safety kit" : "Commander des lunettes ISO 12312-2 et le kit sécurité",
+        text: isEn
+          ? "One certified pair per person, ordered before the June rush. Add a smartphone solar filter if anyone wants to shoot the eclipse — regular phone optics are also unsafe pointed at the sun without filtering. Pack a backup pair per group of four: glasses get dropped."
+          : "Une paire certifiée par personne, commandée avant la cohue de juin. Ajoutez un filtre solaire smartphone si quelqu'un veut filmer — l'optique du téléphone est aussi à risque sans filtre. Prévoyez une paire de secours par groupe de quatre : ça se casse.",
+      },
+      {
+        "@type": "HowToStep",
+        position: 4,
+        name: isEn ? "Plan the observation hour by hour" : "Planifier l'observation heure par heure",
+        text: isEn
+          ? "Be at your spot at least 2 hours before totality. In Spain, totality lands around 20:27-20:32 CEST with the sun very low — practice locating it from your spot the day before. Block a clear meeting point in case the group splits, and time the drive back to accommodation: roads from observation spots clog within minutes of totality ending."
+          : "Soyez sur votre point au moins 2 heures avant la totalité. En Espagne, la totalité arrive autour de 20h27-20h32 CEST avec le soleil très bas — repérez l'angle depuis votre spot la veille. Définissez un point de rendez-vous clair en cas de séparation du groupe, et anticipez le trajet retour : les routes se bouchent en minutes après la fin de la totalité.",
+        url: `${SITE_URL}/${locale}/features/budget`,
+      },
+    ],
+  };
+
+  return (
+    <>
+      <AuthorJsonLd />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(eventLd) }} />
+      <Nav navData={navData} navigationData={navigationData} />
+
+      <main className="min-h-screen bg-[#FFFBF5]">
+
+        {/* ━━━ HERO ━━━ */}
+        <section className="pt-[140px] lg:pt-[200px] pb-16 lg:pb-24 px-6 lg:px-12">
+          <div className="max-w-[900px] mx-auto">
+            <div className="hidden lg:block mb-8">
+              <Breadcrumb items={[
+                { label: isEn ? "Home" : "Accueil", href: `/${locale}` },
+                { label: isEn ? "Solar Eclipse 2026 Trip Planner" : "Voyage Éclipse 2026" },
+              ]} />
+            </div>
+            <p className="font-nanum-pen text-[#F6391A] text-lg lg:text-xl mb-6">
+              {isEn ? "Astrotourism guide & trip planner · August 2026" : "Astrotourisme & guide voyage · Août 2026"}
+            </p>
+            <h1 className="text-[#001E13] text-[38px] lg:text-[72px] font-londrina-solid leading-[1.02] mb-6">
+              {isEn
+                ? "Total Solar Eclipse, 12 August 2026: Iceland & Spain Trip Planner"
+                : "Éclipse Solaire Totale du 12 août 2026 : Le Guide Voyage Islande & Espagne"}
+            </h1>
+            <p className="text-[#001E13]/70 text-lg lg:text-[22px] font-karla leading-[1.8] mb-6">
+              {isEn
+                ? <>Wednesday 12 August 2026. The first total solar eclipse visible from mainland Europe since 11 August 1999. The shadow lands on Greenland, sweeps across western Iceland, and crosses northern Spain at sunset — Galicia, the Ebro Valley, Valencia and Mallorca. Maximum totality is 2 minutes 18 seconds; in Spain&apos;s observable cities you&apos;ll get between 30 seconds and ~1 min 36 s. Mainland France only sees a deep partial (92.2% in Paris, 99.5% in Biarritz) — no totality. This is the complete guide to picking the right spot, getting there, the safety equipment, and planning the trip with a group. If you&apos;re still picking your tools, see our <Link href={`/${locale}/blog/meilleures-applications-voyage-groupe`} className="text-[#F6391A] hover:underline font-semibold">comparison of group travel apps</Link>.</>
+                : <>Mercredi 12 août 2026. La première éclipse totale visible depuis l&apos;Europe continentale depuis le 11 août 1999. L&apos;ombre touche le Groenland, balaie l&apos;ouest de l&apos;Islande, et traverse le nord de l&apos;Espagne au crépuscule — Galice, vallée de l&apos;Èbre, Valence et Majorque. La totalité maximale est de 2 minutes 18 secondes ; dans les villes espagnoles observables, vous aurez entre 30 secondes et ~1 min 36 s. La France métropolitaine ne voit qu&apos;une partielle profonde (92,2 % à Paris, 99,5 % à Biarritz) — pas de totalité. Voici le guide complet pour choisir le bon spot, s&apos;y rendre, s&apos;équiper, et organiser le voyage à plusieurs. Si vous hésitez encore entre les outils, jetez un œil à notre <Link href={`/${locale}/blog/meilleures-applications-voyage-groupe`} className="text-[#F6391A] hover:underline font-semibold">comparatif d&apos;applis de voyage en groupe</Link>.</>}
+            </p>
+            <p className="text-[#001E13]/50 text-sm font-karla mb-6">{isEn ? "10 min read" : "10 min de lecture"}</p>
+            <AuthorBio locale={locale} publishedDate="2026-05-13" modifiedDate="2026-05-13" />
+          </div>
+        </section>
+
+        {/* ━━━ KEY FACTS BOX ━━━ */}
+        <section className="pb-16 lg:pb-20 px-6 lg:px-12">
+          <div className="max-w-[1000px] mx-auto">
+            <div className="bg-white border border-[#001E13]/8 rounded-[24px] lg:rounded-[32px] p-6 lg:p-10">
+              <h2 className="text-[#001E13]/40 font-karla text-xs lg:text-sm uppercase tracking-[0.2em] mb-6">
+                {isEn ? "Eclipse facts" : "Les chiffres de l'éclipse"}
+              </h2>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-6 lg:gap-10">
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Date" : "Date"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">{isEn ? "Wed 12 Aug" : "Mer. 12 août"}</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">2026</p>
+                </div>
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Max totality" : "Totalité max"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">2 min 18 s</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">{isEn ? "off Iceland" : "au large d'Islande"}</p>
+                </div>
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Path" : "Trajectoire"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">IS · ES</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">{isEn ? "+ Greenland" : "+ Groenland"}</p>
+                </div>
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Last in Europe" : "Dernière en Europe"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">1999</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">{isEn ? "27 years ago" : "il y a 27 ans"}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ THE STAKES ━━━ */}
+        <section className="pb-16 lg:pb-24 px-6 lg:px-12">
+          <div className="max-w-[900px] mx-auto space-y-8">
+            <p className="text-[#001E13]/75 text-lg lg:text-[22px] font-karla leading-[1.8]">
+              {isEn
+                ? "Total solar eclipses visible from mainland Europe happen roughly once a generation. The last one was 11 August 1999, when an enormous swathe of France went dark for about two minutes in the middle of summer. The 2026 eclipse skips France entirely — its path of totality crosses eastern Greenland, west and south Iceland, then sweeps across northern Spain at sunset before ending in the Mediterranean. France, despite being so close, only sees a partial eclipse: deep (92-99.5%) but no corona, no darkness, and the sun stays unsafe to look at for the entire phase. To witness the actual total eclipse — and the silent, unforgettable corona — you have to cross into the Spanish path or fly north to Iceland. Two more total eclipses cross Spain after this one (2 August 2027, then an annular on 26 January 2028), making 2026-2028 the unique 'Spanish triple' of European astrotourism."
+                : "Les éclipses totales visibles depuis l'Europe continentale arrivent environ une fois par génération. La précédente, c'était le 11 août 1999, quand une grande partie de la France a basculé dans le noir pendant deux minutes en plein été. L'éclipse 2026 saute complètement la France — sa trajectoire de totalité traverse l'est du Groenland, l'ouest et le sud de l'Islande, puis balaie le nord de l'Espagne au crépuscule avant de finir en Méditerranée. La France, pourtant si proche, ne voit qu'une partielle : profonde (92-99,5 %) mais sans couronne, sans obscurité, et le soleil reste dangereux à regarder sur toute la phase. Pour assister à la vraie totalité — et à la couronne silencieuse, inoubliable — il faut passer dans la bande espagnole ou s'envoler vers l'Islande. Deux autres éclipses totales traverseront l'Espagne après celle-ci (2 août 2027, puis une annulaire le 26 janvier 2028), ce qui fait de 2026-2028 le « triplé espagnol » unique de l'astrotourisme européen."}
+            </p>
+            <p className="text-[#001E13] text-lg lg:text-[22px] font-karla font-bold leading-[1.8]">
+              {isEn
+                ? "WePlanify is the free shared command center for groups chasing the eclipse — location poll, flight or train, accommodation, the day-J observation timeline, and shared budget in one place, in English or French."
+                : "WePlanify, c'est le poste de commandement gratuit et partagé pour les groupes qui chassent l'éclipse — sondage destination, vol ou train, hébergement, timeline d'observation du jour J et budget partagé au même endroit, en français ou anglais."}
+            </p>
+          </div>
+        </section>
+
+        {/* ━━━ TABLE OF CONTENTS ━━━ */}
+        <section className="px-6 lg:px-12">
+          <div className="max-w-[900px] mx-auto">
+            <ArticleTOC
+              title={isEn ? "On this page" : "Sur cette page"}
+              items={[
+                { id: "path", label: isEn ? "The path of totality" : "La trajectoire de la totalité" },
+                { id: "spain-vs-iceland", label: isEn ? "Spain vs Iceland vs cruise" : "Espagne vs Islande vs croisière" },
+                { id: "france", label: isEn ? "What France sees" : "Ce que voit la France" },
+                { id: "safety", label: isEn ? "Safety & glasses" : "Sécurité & lunettes" },
+                { id: "logistics", label: isEn ? "Travel & accommodation" : "Transport & hébergement" },
+                { id: "planning", label: isEn ? "Planning the trip with the crew" : "Organiser le voyage entre potes" },
+                { id: "budget", label: isEn ? "Budget tips" : "Astuces budget" },
+                { id: "faq", label: isEn ? "Frequently asked questions" : "Questions fréquentes" },
+              ]}
+            />
+          </div>
+        </section>
+
+        {/* ━━━ THE PATH ━━━ */}
+        <FadeIn>
+          <section id="path" className="bg-[#001E13] py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[1000px] mx-auto">
+              <h2 className="text-[#FFFBF5] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "The Path of Totality" : "La Trajectoire de la Totalité"}
+              </h2>
+              <p className="text-[#FFFBF5]/50 font-karla text-base lg:text-lg mb-14 max-w-[700px]">
+                {isEn
+                  ? "From Greenland's eastern fjords to the Mediterranean, in roughly 50 minutes. The duration varies wildly by where you stand."
+                  : "Des fjords de l'est du Groenland à la Méditerranée, en environ 50 minutes. La durée varie énormément selon où vous êtes."}
+              </p>
+
+              <div className="space-y-0">
+                {(isEn
+                  ? [
+                      { stop: "Greenland — eastern fjords", desc: "The shadow first touches Earth over the Blosseville Coast and crosses Scoresby Sound, with about 1 min 45 s of totality. The only village in the region, Ittoqqortoormiit, sits ~50 km south of the centerline and stays outside totality. Practical travel access is limited — this leg is for specialists." },
+                      { stop: "Iceland — Westfjords, Snæfellsnes, Reykjavík", desc: "The shadow makes landfall at the Straumnes lighthouse in the Westfjords at 17:43:28 UTC. Látrabjarg gets 2 min 13 s. The Snæfellsnes peninsula, including the iconic Kirkjufell mountain, sits in the path. Reykjavík sees totality start at 17:48:12 UTC for about 1 minute, with the sun ~24.5° above the western horizon. Iceland's total in-shadow time is 6 min 48 s." },
+                      { stop: "Spain — Galicia to Mallorca", desc: "The shadow reaches A Coruña around 20:26 CEST (sun ~11° high), Bilbao at 20:27 (~30 s of totality, sun ~8°), Zaragoza around the same window (~1 min 25 s), Valencia from 20:32 (~1 minute), and Palma de Mallorca at 20:31-20:32 (~1 min 36 s, sun ~4° above the horizon, roughly 10 minutes before sunset). Madrid and Barcelona sit just outside the band — they do not get totality." },
+                      { stop: "Inside the band but easy to miss", desc: "Santander, Burgos, Valladolid, Palencia and León are all in the totality band. The further north and west you are, the slightly higher the sun — but the cloudier the climatology. The Ebro Valley (Huesca, Zaragoza) sits at the statistical sweet spot for August cloud cover and a flat western horizon." },
+                      { stop: "Greatest duration is over open ocean", desc: "The point of greatest duration — 2 minutes 18.2 seconds — is roughly 45 km west of Látrabjarg, in open sea. No island, no port. The only ways to be there are an eclipse cruise or a chartered flight." },
+                    ]
+                  : [
+                      { stop: "Groenland — fjords de l'est", desc: "L'ombre touche d'abord la Terre au-dessus de la Blosseville Coast et traverse Scoresby Sund, avec environ 1 min 45 s de totalité. Le seul village de la région, Ittoqqortoormiit, se situe ~50 km au sud de la ligne centrale et reste hors totalité. L'accès touristique est limité — cette portion est pour spécialistes." },
+                      { stop: "Islande — Westfjords, Snæfellsnes, Reykjavík", desc: "L'ombre touche terre au phare de Straumnes dans les Westfjords à 17h43:28 UTC. Látrabjarg reçoit 2 min 13 s. La péninsule de Snæfellsnes, dont la mythique montagne Kirkjufell, est dans la bande. Reykjavík voit la totalité commencer à 17h48:12 UTC pour environ 1 minute, avec le soleil à ~24,5° au-dessus de l'horizon ouest. Le temps total d'ombre sur l'Islande est de 6 min 48 s." },
+                      { stop: "Espagne — de la Galice à Majorque", desc: "L'ombre atteint A Coruña vers 20h26 CEST (soleil ~11° de hauteur), Bilbao à 20h27 (~30 s de totalité, soleil ~8°), Saragosse à peu près au même créneau (~1 min 25 s), Valence à partir de 20h32 (~1 minute), et Palma de Majorque à 20h31-20h32 (~1 min 36 s, soleil ~4° au-dessus de l'horizon, environ 10 minutes avant le coucher). Madrid et Barcelone sont juste hors bande — pas de totalité." },
+                      { stop: "Dans la bande mais facile à oublier", desc: "Santander, Burgos, Valladolid, Palencia et León sont aussi dans la bande de totalité. Plus on est au nord et à l'ouest, plus le soleil est légèrement haut — mais plus la climatologie est nuageuse. La vallée de l'Èbre (Huesca, Saragosse) se situe au point statistiquement idéal pour la couverture nuageuse d'août et offre un horizon ouest plat." },
+                      { stop: "La durée maximale est en pleine mer", desc: "Le point de durée maximale — 2 minutes 18,2 secondes — se trouve à environ 45 km à l'ouest de Látrabjarg, en pleine mer. Pas d'île, pas de port. Les seules façons d'y être : croisière éclipse ou vol charter." },
+                    ]
+                ).map((item, i) => (
+                  <div key={i} className="flex gap-6 lg:gap-8">
+                    <div className="flex flex-col items-center flex-shrink-0">
+                      <div className="w-4 h-4 bg-[#F6391A] rounded-full" />
+                      {i < 4 && <div className="w-0.5 flex-1 bg-[#FFFBF5]/10" />}
+                    </div>
+                    <div className="pb-12 lg:pb-16">
+                      <h3 className="text-[#FFFBF5] text-xl lg:text-2xl font-londrina-solid mb-2">{item.stop}</h3>
+                      <p className="text-[#FFFBF5]/55 text-sm lg:text-base font-karla leading-[1.8]">{item.desc}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ SPAIN VS ICELAND VS CRUISE ━━━ */}
+        <section id="spain-vs-iceland" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24 bg-[#FFFBF5]">
+          <div className="max-w-[1000px] mx-auto">
+            <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+              {isEn ? "Spain vs Iceland vs Cruise" : "Espagne vs Islande vs Croisière"}
+            </h2>
+            <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-10 max-w-[700px]">
+              {isEn
+                ? "Three honest options, each with a real trade-off. The right one depends on what you optimise for — clear sky odds, totality duration, or experience."
+                : "Trois options honnêtes, chacune avec un vrai trade-off. Le bon choix dépend de ce que vous optimisez — probabilité de ciel clair, durée de la totalité, ou expérience."}
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Option 1" : "Option 1"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Inland northern Spain" : "Nord de l'Espagne intérieur"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "The Ebro Valley, Huesca, Zaragoza and the plains around them — best August cloud-cover statistics on the entire path (~35% cloud risk). Flat western horizon, easy road access, mid-range hotels. Trade-off: totality is short (~1-1.5 min) and the sun is low (8-11°)." : "La vallée de l'Èbre, Huesca, Saragosse et les plaines autour — meilleures statistiques nuages d'août sur toute la trajectoire (~35 % de risque). Horizon ouest plat, accès route facile, hôtels milieu de gamme. Trade-off : la totalité est courte (~1-1,5 min) et le soleil bas (8-11°)."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Option 2" : "Option 2"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Mallorca" : "Majorque"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "Palma sees ~1 min 36 s of totality, the longest of any easily reachable city. Beach setting with a clear western sea horizon. Trade-off: the sun is very low (~4°), ~10 min before sunset, so any cliff or building to the west kills the view. Hotel rates have already roughly tripled for the night of 11-12 August." : "Palma voit ~1 min 36 s de totalité, la plus longue parmi les villes facilement accessibles. Cadre balnéaire avec horizon mer ouest dégagé. Trade-off : le soleil est très bas (~4°), à ~10 min du coucher, donc toute falaise ou bâtiment à l'ouest tue la vue. Les hôtels ont déjà roughly triplé sur la nuit du 11-12 août."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Option 3" : "Option 3"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Iceland or cruise" : "Islande ou croisière"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "Iceland gives the most dramatic experience and the highest sun (~24° in Reykjavík) but pays in cloud risk (70-85% average August cover). A Mediterranean eclipse cruise (Costa from ~€450, CFC Renaissance from €1,279, Princess, Holland America) trades a fixed spot for meteorological flexibility on the day." : "L'Islande offre l'expérience la plus spectaculaire et le soleil le plus haut (~24° à Reykjavík) mais paie en risque nuage (70-85 % de couverture moyenne en août). Une croisière éclipse en Méditerranée (Costa dès ~450 €, CFC Renaissance dès 1 279 €, Princess, Holland America) échange un point fixe contre la flexibilité météo du jour J."}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ WHAT FRANCE SEES ━━━ */}
+        <FadeIn>
+          <section id="france" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[1000px] mx-auto">
+              <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "What France Actually Sees" : "Ce que la France Voit Vraiment"}
+              </h2>
+              <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-12 max-w-[700px]">
+                {isEn
+                  ? "A deep partial — but not a total. Important to be clear on this with the group, especially anyone who remembers the 1999 eclipse from France."
+                  : "Une partielle profonde — mais pas une totalité. Important de bien clarifier avec le groupe, surtout ceux qui ont vu l'éclipse de 1999 depuis la France."}
+              </p>
+
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-10">
+                <div className="bg-[#001E13] rounded-[24px] p-8 lg:p-10">
+                  <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Partial obscuration" : "Obscurcissement partiel"}</p>
+                  <h3 className="text-[#FFFBF5] text-3xl lg:text-4xl font-londrina-solid mb-6">{isEn ? "City by city" : "Ville par ville"}</h3>
+                  <ul className="space-y-3 text-[#FFFBF5]/70 font-karla text-sm lg:text-base leading-[1.7]">
+                    <li>{isEn ? "→ Biarritz: up to 99.5% (closest to the path)" : "→ Biarritz : jusqu'à 99,5 % (le plus proche de la bande)"}</li>
+                    <li>{isEn ? "→ Marseille / Nice: ~95%" : "→ Marseille / Nice : ~95 %"}</li>
+                    <li>{isEn ? "→ Bordeaux / Toulouse: ~96-97%" : "→ Bordeaux / Toulouse : ~96-97 %"}</li>
+                    <li>{isEn ? "→ Paris: 92.2%" : "→ Paris : 92,2 %"}</li>
+                    <li>{isEn ? "→ Timing: ~19:30 to ~20:30 Paris time, low sun" : "→ Horaire : ~19h30 à ~20h30 heure de Paris, soleil bas"}</li>
+                  </ul>
+                </div>
+
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-8 lg:p-10">
+                  <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Why 99% is not 100%" : "Pourquoi 99 % n'est pas 100 %"}</p>
+                  <h3 className="text-[#001E13] text-3xl lg:text-4xl font-londrina-solid mb-6">{isEn ? "What you miss" : "Ce que vous ratez"}</h3>
+                  <ul className="space-y-3 text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.7]">
+                    <li>{isEn ? "→ The corona — only visible when the sun is 100% covered" : "→ La couronne — visible uniquement à 100 % de couverture"}</li>
+                    <li>{isEn ? "→ The darkness — night does not actually fall at 99%" : "→ L'obscurité — la nuit ne tombe pas vraiment à 99 %"}</li>
+                    <li>{isEn ? "→ The naked-eye safe window — never at partial, always wear glasses" : "→ La fenêtre œil-nu — jamais en partielle, lunettes obligatoires"}</li>
+                    <li>{isEn ? "→ The temperature drop and the bird silence" : "→ La baisse de température et le silence des oiseaux"}</li>
+                    <li>{isEn ? "→ The 360° sunset effect on the horizon" : "→ L'effet coucher de soleil 360° sur l'horizon"}</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ SAFETY ━━━ */}
+        <section id="safety" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24 bg-[#FFFBF5]">
+          <div className="max-w-[1000px] mx-auto">
+            <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+              {isEn ? "Safety & ISO 12312-2 Glasses" : "Sécurité & Lunettes ISO 12312-2"}
+            </h2>
+            <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-10 max-w-[700px]">
+              {isEn
+                ? "Solar retinopathy is silent — you don't feel the damage until it's done. Get the right glasses early and bring spares."
+                : "La rétinopathie solaire est silencieuse — on ne sent rien jusqu'à ce que le dommage soit fait. Achetez les bonnes lunettes tôt et prévoyez des paires de secours."}
+            </p>
+
+            <div className="space-y-6">
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6 lg:p-8">
+                <h3 className="text-[#001E13] font-londrina-solid text-xl lg:text-2xl mb-3">{isEn ? "The certification to look for" : "La certification à vérifier"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.8]">
+                  {isEn
+                    ? "ISO 12312-2:2015 — printed on the inside of the glasses — plus the CE marking for Europe. Anything without both is unsafe, including very dark welder's glass below shade 14, X-ray film, smoked glass, fully exposed photographic negatives, or stacked sunglasses. Glasses older than three years should be replaced; the filter degrades."
+                    : "ISO 12312-2:2015 — imprimé à l'intérieur des lunettes — plus le marquage CE pour l'Europe. Sans ces deux mentions, c'est dangereux : verre de soudeur inférieur à teinte 14, film X, verre fumé, négatif photo exposé, lunettes de soleil empilées. À remplacer après trois ans : le filtre se dégrade."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6 lg:p-8">
+                <h3 className="text-[#001E13] font-londrina-solid text-xl lg:text-2xl mb-3">{isEn ? "Where to buy in France" : "Où en acheter en France"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.8]">
+                  {isEn
+                    ? "Pharmacies (advance sales typically open in June), Bresser.fr, Astronome.fr, Stelvision (Soleils Noirs), and MyEclipseGlasses or VOLTNGO on Amazon. Order before the June rush — supply gets tight in July as media coverage ramps up. One pair per person, plus a backup pair per group of four."
+                    : "Pharmacies (préventes habituellement en juin), Bresser.fr, Astronome.fr, Stelvision (Soleils Noirs), et MyEclipseGlasses ou VOLTNGO sur Amazon. Commandez avant la cohue de juin — la disponibilité se tend en juillet quand la couverture médiatique monte. Une paire par personne, plus une paire de secours par groupe de quatre."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6 lg:p-8">
+                <h3 className="text-[#001E13] font-londrina-solid text-xl lg:text-2xl mb-3">{isEn ? "Smartphone & camera" : "Smartphone & appareil photo"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.8]">
+                  {isEn
+                    ? "Pointing a phone camera at the partial eclipse without a solar filter can damage the sensor and is not safe through the screen either. Use a screw-on or magnetic solar filter, or accept that the eclipse is one of the few events where keeping the phone in your pocket is the right call. During totality only (in the totality band) you can look at the sun and shoot freely."
+                    : "Pointer un téléphone vers la partielle sans filtre solaire peut endommager le capteur et l'écran n'est pas un compromis sûr non plus. Utilisez un filtre solaire vissable ou magnétique, ou acceptez que l'éclipse est un des rares événements où ranger le téléphone est la bonne décision. Pendant la totalité uniquement (et uniquement dans la bande), vous pouvez regarder le soleil et photographier librement."}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ LOGISTICS ━━━ */}
+        <FadeIn>
+          <section id="logistics" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[1000px] mx-auto">
+              <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "Travel & Accommodation" : "Transport & Hébergement"}
+              </h2>
+              <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-12 max-w-[700px]">
+                {isEn
+                  ? "Headline cities are largely booked. The play is either to widen the search to smaller towns inside the path, or to accept a longer drive on the day."
+                  : "Les villes vedettes sont largement réservées. Le bon coup, c'est soit d'élargir la recherche aux plus petites villes dans la bande, soit d'accepter un trajet plus long le jour J."}
+              </p>
+
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-10">
+                <div className="bg-[#001E13] rounded-[24px] p-8 lg:p-10">
+                  <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Spain" : "Espagne"}</p>
+                  <h3 className="text-[#FFFBF5] text-3xl lg:text-4xl font-londrina-solid mb-6">{isEn ? "Getting there" : "Comment y aller"}</h3>
+                  <ul className="space-y-3 text-[#FFFBF5]/70 font-karla text-sm lg:text-base leading-[1.7]">
+                    <li>{isEn ? "→ Paris → Bilbao: short direct flight, ~1h50" : "→ Paris → Bilbao : vol direct court, ~1h50"}</li>
+                    <li>{isEn ? "→ Paris → Bilbao by train: ~14-15h via Hendaye" : "→ Paris → Bilbao en train : ~14-15h via Hendaye"}</li>
+                    <li>{isEn ? "→ Paris → Zaragoza / Valencia / Palma: direct flights from CDG/ORY" : "→ Paris → Saragosse / Valence / Palma : vols directs depuis CDG/ORY"}</li>
+                    <li>{isEn ? "→ Drive from southwest France to Bilbao or Pamplona: ~3-5 h" : "→ Voiture depuis le sud-ouest vers Bilbao ou Pampelune : ~3-5 h"}</li>
+                    <li>{isEn ? "→ Headline cities (Zaragoza, Valencia, Palma): hotels mostly gone — try Logroño, Tudela, Castellón" : "→ Villes vedettes (Saragosse, Valence, Palma) : hôtels largement partis — essayez Logroño, Tudela, Castellón"}</li>
+                  </ul>
+                </div>
+
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-8 lg:p-10">
+                  <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Iceland & cruise" : "Islande & croisière"}</p>
+                  <h3 className="text-[#001E13] text-3xl lg:text-4xl font-londrina-solid mb-6">{isEn ? "Getting there" : "Comment y aller"}</h3>
+                  <ul className="space-y-3 text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.7]">
+                    <li>{isEn ? "→ Paris CDG → Reykjavík (KEF): ~3h30 direct, Icelandair (~16 flights/week) and easyJet" : "→ Paris CDG → Reykjavík (KEF) : ~3h30 direct, Icelandair (~16 vols/semaine) et easyJet"}</li>
+                    <li>{isEn ? "→ Rent a car at KEF to reach Snæfellsnes (~2h30 drive)" : "→ Voiture de location à KEF pour rejoindre Snæfellsnes (~2h30 de route)"}</li>
+                    <li>{isEn ? "→ Reykjavík hotels: mostly sold out, Reykjavik Edition listed at $4,399/night" : "→ Hôtels de Reykjavík : largement sold out, le Reykjavik Edition annoncé à 4 399 $/nuit"}</li>
+                    <li>{isEn ? "→ Costa Cruises eclipse cruise: 7 nights from ~€450/pers" : "→ Croisière éclipse Costa : 7 nuits dès ~450 €/pers"}</li>
+                    <li>{isEn ? "→ CFC Renaissance: 6 nights from Marseille, from €1,279/pers" : "→ CFC Renaissance : 6 nuits depuis Marseille, dès 1 279 €/pers"}</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ PLANNING THE TRIP ━━━ */}
+        <section id="planning" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24 bg-[#FFFBF5]">
+          <div className="max-w-[900px] mx-auto space-y-8">
+            <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08]">
+              {isEn ? "Planning the Trip with the Crew" : "Organiser le Voyage entre Potes"}
+            </h2>
+            <p className="text-[#001E13]/75 text-lg lg:text-[22px] font-karla leading-[1.8]">
+              {isEn
+                ? <>An eclipse trip has a brutal forcing function: 30 seconds to 2 minutes of payoff in a single moment, after months of planning. The destination call is the hardest — Iceland enthusiasts and Mediterranean enthusiasts often want very different trips. Run a <Link href={`/${locale}/features/polls`} className="text-[#F6391A] hover:underline font-semibold">group poll</Link> early on the three real options (inland Spain, Mallorca, Iceland), with each person ranking by what they actually optimise for — clear-sky odds, totality duration, or experience. The poll is the smallest piece of work that prevents an entire trip from drifting toward the loudest voice.</>
+                : <>Un voyage éclipse a une contrainte brutale : 30 secondes à 2 minutes de récompense en un seul instant, après des mois de préparation. Le choix de la destination est la décision la plus dure — les amoureux d&apos;Islande et ceux de Méditerranée veulent souvent des voyages très différents. Lancez un <Link href={`/${locale}/features/polls`} className="text-[#F6391A] hover:underline font-semibold">sondage de groupe</Link> tôt sur les trois vraies options (Espagne intérieure, Majorque, Islande), avec chaque personne qui classe selon ce qu&apos;elle optimise vraiment — probabilité de ciel clair, durée de la totalité, ou expérience. Le sondage, c&apos;est le plus petit travail qui empêche un voyage entier de glisser vers la voix la plus forte.</>}
+            </p>
+            <p className="text-[#001E13]/75 text-lg lg:text-[22px] font-karla leading-[1.8]">
+              {isEn
+                ? <>The day-J <Link href={`/${locale}/features/itinerary`} className="text-[#F6391A] hover:underline font-semibold">shared itinerary</Link> is non-negotiable. Block: arrival at the observation spot at least 2 hours before totality, glasses-on for the partial phase, the totality window (minute by minute), the post-totality partial (still dangerous, glasses back on), and the drive back. The hours after totality are when roads clog and cellular networks die — agree on a meeting point and a fallback channel before the partial even starts.</>
+                : <>L&apos;<Link href={`/${locale}/features/itinerary`} className="text-[#F6391A] hover:underline font-semibold">itinéraire partagé</Link> du jour J n&apos;est pas négociable. Bloquez : arrivée sur le spot au moins 2 heures avant la totalité, lunettes en partielle, fenêtre de totalité (minute par minute), partielle post-totalité (toujours dangereuse, lunettes remises), et le trajet retour. Les heures après la totalité, c&apos;est routes bouchées et réseau mort — convenez d&apos;un point de rendez-vous et d&apos;un canal de secours avant même le début de la partielle.</>}
+            </p>
+          </div>
+        </section>
+
+        {/* ━━━ BUDGET TIPS ━━━ */}
+        <FadeIn>
+          <section id="budget" className="bg-[#001E13] py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[900px] mx-auto space-y-8">
+              <h2 className="text-[#FFFBF5] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "Budget Tips" : "Astuces Budget"}
+              </h2>
+              <p className="text-[#FFFBF5]/65 text-lg lg:text-[22px] font-karla leading-[1.8]">
+                {isEn
+                  ? <>Eclipse trips skew the normal budget pattern: accommodation prices on 11-12 August are the dominant line, often 3-10× normal rates, while transport is closer to typical August prices. Hotels.com reported a 445% surge in eclipse-destination searches, and Palencia rooms have appeared at €1,095/night. Set up a <Link href={`/${locale}/features/budget`} className="text-[#EEF899] hover:underline font-semibold">shared budget tracker</Link> with the night of 11-12 August explicitly carved out as a separate line, and decide as a group whether the headline city is worth the premium or whether a 30-minute drive to a smaller town is the better trade.</>
+                  : <>Les voyages éclipse déforment le pattern budget habituel : les prix d&apos;hébergement la nuit du 11-12 août dominent la ligne, souvent 3-10× le tarif normal, tandis que le transport reste proche d&apos;août classique. Hotels.com a rapporté +445 % de recherches sur destinations éclipse, et des chambres à Palencia sont apparues à 1 095 €/nuit. Mettez en place un <Link href={`/${locale}/features/budget`} className="text-[#EEF899] hover:underline font-semibold">suivi de budget partagé</Link> avec la nuit du 11-12 août en ligne séparée explicite, et décidez en groupe si la ville vedette vaut le premium ou si 30 minutes de route vers une petite ville est le meilleur trade.</>}
+              </p>
+              <p className="text-[#FFFBF5]/65 text-lg lg:text-[22px] font-karla leading-[1.8]">
+                {isEn
+                  ? "A serviced apartment for 4-6 people in a smaller town inside the totality band (Logroño, Tudela, Castellón on the Spanish side; Borgarnes or Stykkishólmur on the Snæfellsnes peninsula in Iceland) routinely beats hotel rooms in headline cities by 40-60%, while keeping you fully inside totality. The trade-off is that the dinner options narrow — book restaurants for 13 August now, not on the day."
+                  : "Un appartement partagé à 4-6 dans une plus petite ville de la bande (Logroño, Tudela, Castellón côté Espagne ; Borgarnes ou Stykkishólmur sur la péninsule de Snæfellsnes en Islande) bat régulièrement les chambres d'hôtel des villes vedettes de 40-60 %, tout en restant pleinement dans la totalité. Trade-off : l'offre restauration se réduit — réservez les restos du 13 août maintenant, pas le jour même."}
+              </p>
+              <p className="text-[#FFFBF5]/65 text-lg lg:text-[22px] font-karla leading-[1.8]">
+                {isEn
+                  ? "Don't skimp on the glasses. A €5-15 ISO 12312-2 pair per person plus a backup is one of the smallest lines in the entire budget, and it's the only line where shortcutting can actually injure someone in the group."
+                  : "Pas de compromis sur les lunettes. 5-15 € de lunettes ISO 12312-2 par personne plus une de secours, c'est l'une des plus petites lignes du budget, et la seule où un raccourci peut vraiment blesser quelqu'un dans le groupe."}
+              </p>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ FAQ ━━━ */}
+        <section id="faq" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+          <div className="max-w-[800px] mx-auto">
+            <h2 className="text-3xl lg:text-5xl font-londrina-solid text-[#001E13] mb-10 text-center">
+              {isEn ? "Frequently Asked Questions" : "Questions Fréquemment Posées"}
+            </h2>
+            <div className="space-y-6">
+              {faqItems.map((item, i) => (
+                <details key={i} className="group border-b border-[#001E13]/10 pb-5">
+                  <summary className="flex items-start justify-between cursor-pointer list-none font-karla font-semibold text-[#001E13] text-base lg:text-lg">
+                    <span className="pr-4">{item.q}</span>
+                    <span className="text-[#F6391A] text-xl leading-none mt-0.5 group-open:rotate-45 transition-transform">+</span>
+                  </summary>
+                  <p className="mt-3 text-[#001E13]/70 text-sm lg:text-base font-karla leading-relaxed">{item.a}</p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ DISCOVER MORE ━━━ */}
+        <section className="py-12 lg:py-16 px-6 lg:px-12 bg-[#FFFBF5]">
+          <div className="max-w-[1200px] mx-auto">
+            <h2 className="text-2xl lg:text-4xl font-londrina-solid text-[#001E13] text-center mb-10">{isEn ? "Discover More" : "Découvrir aussi"}</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              <Link href={`/${locale}/hellfest-2026-trip-planner`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Hellfest 2026 Trip Planner" : "Voyage Hellfest 2026"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "Four days of metal in Clisson, France." : "Quatre jours de metal à Clisson."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read more →" : "En savoir plus →"}</span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/tomorrowland-2026-trip-planner`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Tomorrowland 2026 Trip Planner" : "Voyage Tomorrowland 2026"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "Two weekends in Boom, Belgium." : "Deux week-ends à Boom, Belgique."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read more →" : "En savoir plus →"}</span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/trip-with-friends`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Trip with Friends" : "Voyage entre Amis"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "Plan any group trip effortlessly." : "Organisez n'importe quel voyage de groupe."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read more →" : "En savoir plus →"}</span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/guides/plan-group-trip`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Group Trip Guide" : "Guide Voyage de Groupe"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "The complete step-by-step guide." : "Le guide complet étape par étape."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read the guide →" : "Lire le guide →"}</span>
+                </div>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ CTA ━━━ */}
+        <section className="py-16 lg:py-24 px-6 lg:px-12">
+          <div className="max-w-[1200px] mx-auto">
+            <div className="bg-gradient-to-br from-[#F6391A] to-[#d42d10] rounded-[24px] lg:rounded-[40px] p-8 lg:p-16 text-center">
+              <h2 className="text-3xl lg:text-5xl font-londrina-solid text-[#FFFBF5] mb-4">
+                {isEn ? "Build Your Eclipse Trip" : "Construisez Votre Voyage Éclipse"}
+              </h2>
+              <p className="text-[#FFFBF5]/80 font-karla text-base lg:text-lg max-w-2xl mx-auto mb-8 leading-relaxed">
+                {isEn ? "Destination poll, flights or train, accommodation in the totality band, day-J timeline, shared budget — one plan, your whole crew on the same page." : "Sondage destination, vols ou train, hébergement dans la bande, timeline du jour J, budget partagé — un seul plan, toute votre bande alignée."}
+              </p>
+              <div className="flex justify-center">
+                <Link href={`https://app.weplanify.com/${locale}/register?utm_source=landing&utm_campaign=solar-eclipse-2026&template=solar-eclipse-2026`}>
+                  <PulsatingButton className="font-karla font-bold">{isEn ? "Start planning" : "Commencer"}</PulsatingButton>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+      </main>
+      <Footer footerData={footerData} />
+    </>
+  );
+}

--- a/src/app/[locale]/tomorrowland-2026-trip-planner/page.tsx
+++ b/src/app/[locale]/tomorrowland-2026-trip-planner/page.tsx
@@ -1,0 +1,611 @@
+import { Metadata } from "next";
+import Nav from "@/components/Nav";
+import Footer from "@/components/Footer";
+import { sanityFetch } from "@/sanity/lib/fetch";
+import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
+import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
+import { PulsatingButton } from "@/components/magicui/pulsating-button";
+import Link from "next/link";
+import Breadcrumb from "@/components/Breadcrumb";
+import ArticleTOC from "@/components/ArticleTOC";
+import { setRequestLocale } from "next-intl/server";
+import { generateMetadataFromSanity } from "@/lib/metadata";
+import { routing } from "@/i18n/routing";
+import FadeIn from "@/components/FadeIn";
+import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
+
+type Props = { params: Promise<{ locale: string }> };
+const SITE_URL = "https://www.weplanify.com";
+const PATHNAME = "/tomorrowland-2026-trip-planner";
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const metadata = await generateMetadataFromSanity(locale, PATHNAME);
+  const isEn = locale === "en";
+  const title = isEn
+    ? "Tomorrowland 2026: The Trip Planner — Travel, DreamVille, Pearls & Group Budget | WePlanify"
+    : "Tomorrowland 2026 : Le Guide Voyage — Transport, DreamVille, Pearls et Budget Partagé | WePlanify";
+  const description = isEn
+    ? "Everything for Tomorrowland 2026 in Boom (17-19 & 24-26 July): Global Journey sold out, Eurostar from Paris, DreamVille tiers, Antwerp hotels, the Pearl cashless system and shared group budget for the Consciencia weekends."
+    : "Tout sur Tomorrowland 2026 à Boom (17-19 et 24-26 juillet) : Global Journey sold out, Eurostar depuis Paris, niveaux DreamVille, hôtels à Anvers, le cashless Pearl et le budget partagé pour les week-ends Consciencia.";
+  const currentUrl = `${SITE_URL}/${locale}${PATHNAME}`;
+  return {
+    ...metadata, title, description,
+    authors: [{ name: "Alex Martin" }],
+    openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl },
+    twitter: { ...metadata.twitter, title, description },
+    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+  };
+}
+
+export default async function Tomorrowland2026Page({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const isEn = locale === "en";
+
+  const [navData, navigationData, footerData]: [NavType, Navigation | null, FooterType | null] =
+    await Promise.all([
+      sanityFetch<NavType>({ query: navQuery, params: { locale }, tags: ["nav"] }),
+      sanityFetch<Navigation>({ query: navigationQuery, params: { locale }, tags: ["navigation"] }),
+      sanityFetch<FooterType>({ query: footerQuery, params: { locale }, tags: ["footer"] }),
+    ]);
+
+  const breadcrumbLd = {
+    "@context": "https://schema.org", "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: isEn ? "Home" : "Accueil", item: `${SITE_URL}/${locale}` },
+      { "@type": "ListItem", position: 2, name: isEn ? "Tomorrowland 2026 Trip Planner" : "Voyage Tomorrowland 2026", item: `${SITE_URL}/${locale}${PATHNAME}` },
+    ],
+  };
+
+  const articleLd = {
+    "@context": "https://schema.org", "@type": "Article",
+    headline: isEn ? "Tomorrowland 2026: The Trip Planner" : "Tomorrowland 2026 : Le Guide Voyage",
+    author: { "@type": "Person", name: "Alex Martin", jobTitle: "Travel Editor" },
+    publisher: { "@type": "Organization", name: "WePlanify", url: SITE_URL },
+    datePublished: "2026-05-13", dateModified: "2026-05-13",
+    mainEntityOfPage: { "@type": "WebPage", "@id": `${SITE_URL}/${locale}${PATHNAME}` },
+  };
+
+  const musicEventLd = {
+    "@context": "https://schema.org",
+    "@type": "MusicFestival",
+    name: "Tomorrowland Belgium 2026 — Consciencia",
+    description: isEn
+      ? "Tomorrowland Belgium 2026, the two-weekend electronic music festival at De Schorre in Boom, on 17-19 July and 24-26 July 2026. 500+ artists across 16 stages, theme 'Consciencia', headlined by Calvin Harris (Tomorrowland Belgium debut), David Guetta, Martin Garrix and Armin van Buuren."
+      : "Tomorrowland Belgium 2026, le festival électronique deux week-ends à De Schorre à Boom, les 17-19 juillet et 24-26 juillet 2026. Plus de 500 artistes sur 16 scènes, thème « Consciencia », têtes d'affiche Calvin Harris (première au Tomorrowland Belgium), David Guetta, Martin Garrix et Armin van Buuren.",
+    image: [`${SITE_URL}/header-bg.webp`],
+    startDate: "2026-07-17",
+    endDate: "2026-07-26",
+    eventStatus: "https://schema.org/EventScheduled",
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    organizer: { "@type": "Organization", name: "Tomorrowland", url: "https://www.tomorrowland.com" },
+    offers: {
+      "@type": "Offer",
+      url: "https://www.tomorrowland.com",
+      availability: "https://schema.org/SoldOut",
+      validFrom: "2025-12-08",
+    },
+    location: {
+      "@type": "Place",
+      name: "De Schorre",
+      address: { "@type": "PostalAddress", addressLocality: "Boom", addressRegion: "Antwerp Province", addressCountry: "BE" },
+    },
+  };
+
+  const faqItems = isEn
+    ? [
+        { q: "When and where is Tomorrowland 2026?", a: "Two weekends at De Schorre in Boom, Belgium, between Antwerp and Brussels. Weekend 1 runs Friday 17 to Sunday 19 July 2026; Weekend 2 runs Friday 24 to Sunday 26 July 2026. The festival is strictly 18+ (you must be born in 2008 or earlier) and the 2026 theme is 'Consciencia'. 16 stages, 500+ artists across both weekends, around 70,000 attendees per day for a total of ~400,000 over the eleven festival days." },
+        { q: "Is Tomorrowland 2026 sold out?", a: "Effectively yes. Global Journey travel packages sold out worldwide on 17 January 2026, the Belgian sale on 24 January and the worldwide sale on 31 January typically clear in under an hour. The only path forward is official resale on the Tomorrowland platform — listings appear when other fans cancel, sometimes daily, sometimes only days before the gates open. Tickets bought outside the official channels (Telegram, Vinted, Facebook marketplace) are routinely refused at the gate scan, so don't gamble." },
+        { q: "How do I get to Boom from Paris, Lille or London?", a: "From Paris-Nord, Eurostar (which absorbed Thalys in 2023) reaches Brussels-Midi in about 1h22, from around €30 if booked ahead. From Lille-Europe count around 35-50 min. From London St Pancras direct trains take ~1h55. From Brussels-Midi or Antwerp-Centraal, SNCB trains run every ~30 min to Boom (~32 min, €6-10), then a free festival shuttle runs from Boom station to the gates. By plane, Brussels Zaventem (BRU) is 33 km / 20 min by road; Antwerp Airport is closer but has fewer connections." },
+        { q: "What are the DreamVille camping tiers?", a: "DreamVille is the on-site camping village, open 5 days from Thursday around 11:00 to Monday. New for 2026, the Solara tier comes with power outlets — a meaningful upgrade for anyone who has spent a festival hunting a charging station. Marivela offers A/C and private bathrooms. Magnificent Greens is the BYO-tent option, Easy Tent and Spectacular are pre-pitched, Relax and Cabana sit in the middle. Premium tiers start around €2,700 per person for the weekend; specific tier pricing varies year to year." },
+        { q: "How does the Pearl cashless system work?", a: "On-site, the only currency is the Pearl. €20 buys 11 Pearls (about €1.82 each). Top up online before the festival — every €100 in online top-up earns a 2-Pearl bonus, and the unspent balance is auto-refunded after the festival. On-site top-ups are also possible but the unspent balance needs to be manually claimed before the announced deadline. Bring a backup top-up plan in case the on-site network is slow — it routinely is around peak hours." },
+        { q: "Where should I stay if I missed Global Journey?", a: "Three honest options. DreamVille on the festival grounds (walking distance to gates, the full festival experience), Antwerp city centre (~20 km north, 30 min by train, hotels €150-400/night during the festival, good restaurants and bars), or Brussels (~30 km south, broader hotel inventory but a longer commute). A serviced apartment split between 4-6 friends in Antwerp typically beats hotel rooms by 30-50% on price." },
+        { q: "How do you organise a Tomorrowland trip with a group of friends?", a: "Tickets and packages are individual — keep them out of the shared pool. The shared pool is for transport (Eurostar, shuttle, taxi), accommodation, group meals before and after, and the on-site Pearl float. Set categories from day one (transport, hotel, food, Pearls) so the math doesn't collapse on the way home. WePlanify keeps each category clean across the two weekends if your group is splitting, and rotates who fronts each expense." },
+      ]
+    : [
+        { q: "Quand et où se tient Tomorrowland 2026 ?", a: "Deux week-ends à De Schorre à Boom, en Belgique, entre Anvers et Bruxelles. Week-end 1 du vendredi 17 au dimanche 19 juillet 2026 ; week-end 2 du vendredi 24 au dimanche 26 juillet 2026. Le festival est strictement +18 (né en 2008 ou avant) et le thème 2026 est « Consciencia ». 16 scènes, plus de 500 artistes sur les deux week-ends, environ 70 000 personnes par jour pour un total d'environ 400 000 sur les onze jours de festival." },
+        { q: "Tomorrowland 2026 est-il sold out ?", a: "Concrètement oui. Les Global Journey ont été sold out dans le monde entier le 17 janvier 2026, la vente belge le 24 janvier et la vente mondiale du 31 janvier partent habituellement en moins d'une heure. Le seul chemin restant, c'est la revente officielle sur la plateforme Tomorrowland — des billets réapparaissent quand des festivaliers annulent, parfois chaque jour, parfois quelques jours seulement avant l'ouverture. Les billets achetés hors canaux officiels (Telegram, Vinted, Marketplace) sont régulièrement refusés au scan, donc ne jouez pas avec le feu." },
+        { q: "Comment rejoindre Boom depuis Paris, Lille ou Londres ?", a: "Depuis Paris-Nord, Eurostar (qui a absorbé Thalys en 2023) rejoint Bruxelles-Midi en 1h22 environ, à partir de 30 € en réservant à l'avance. Depuis Lille-Europe, comptez 35 à 50 min. Depuis Londres St Pancras, train direct en ~1h55. De Bruxelles-Midi ou Anvers-Centraal, les trains SNCB partent toutes les ~30 min vers Boom (~32 min, 6-10 €), puis une navette festival gratuite relie la gare de Boom aux portes. En avion, Bruxelles-Zaventem (BRU) est à 33 km / 20 min ; l'aéroport d'Anvers est plus proche mais moins desservi." },
+        { q: "Quels sont les niveaux de camping DreamVille ?", a: "DreamVille, c'est le village de camping sur site, ouvert 5 jours du jeudi vers 11h au lundi. Nouveauté 2026, le tier Solara intègre des prises électriques — un vrai upgrade pour qui a déjà passé un festival à chasser une borne de charge. Marivela propose climatisation et salle de bain privée. Magnificent Greens, c'est l'option tente personnelle ; Easy Tent et Spectacular sont des tentes prémontées ; Relax et Cabana se situent entre les deux. Les tiers premium commencent autour de 2 700 € par personne pour le week-end ; la grille tarifaire varie d'une année sur l'autre." },
+        { q: "Comment fonctionne le cashless Pearl ?", a: "Sur site, la seule monnaie c'est le Pearl. 20 € achètent 11 Pearls (environ 1,82 € l'unité). Rechargez en ligne avant le festival — chaque 100 € rechargé en ligne donne un bonus de 2 Pearls, et le solde non utilisé est remboursé automatiquement après le festival. Le rechargement sur site est possible mais le solde non utilisé doit être réclamé manuellement avant la deadline annoncée. Prévoyez un plan B au rechargement, le réseau sur place rame souvent aux heures de pointe." },
+        { q: "Où dormir si on n'a pas eu de Global Journey ?", a: "Trois options honnêtes. DreamVille sur le site du festival (à pied des portes, l'expérience festival complète), Anvers centre (~20 km au nord, 30 min en train, hôtels 150-400 €/nuit sur le festival, beaux restos et bars), ou Bruxelles (~30 km au sud, offre hôtelière plus large mais trajet plus long). Un appartement partagé entre 4-6 potes à Anvers bat souvent les chambres d'hôtel de 30-50 %." },
+        { q: "Comment organiser un Tomorrowland entre potes ?", a: "Les billets et packages sont individuels — gardez-les hors du pot commun. Le pot commun, c'est pour le transport (Eurostar, navette, taxi), l'hébergement, les restos avant et après, et le float Pearl sur place. Posez les catégories dès le départ (transport, hôtel, restos, Pearls) pour ne pas finir le calcul au retour. WePlanify garde chaque catégorie au propre sur les deux week-ends si votre groupe se sépare, et fait tourner les avances dans la bande." },
+      ];
+
+  const faqLd = {
+    "@context": "https://schema.org", "@type": "FAQPage",
+    mainEntity: faqItems.map((item) => ({ "@type": "Question", name: item.q, acceptedAnswer: { "@type": "Answer", text: item.a } })),
+  };
+
+  const howToLd = {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: isEn ? "How to plan a Tomorrowland 2026 trip to Boom" : "Comment organiser un voyage à Tomorrowland 2026 à Boom",
+    description: isEn
+      ? "Two months out, here is how to lock the trip: official resale watch, Eurostar from Paris, DreamVille vs Antwerp, Pearl float and group budget setup."
+      : "À deux mois, voici comment verrouiller le voyage : veille revente officielle, Eurostar depuis Paris, DreamVille vs Anvers, float Pearl et budget partagé.",
+    totalTime: "PT45M",
+    step: [
+      {
+        "@type": "HowToStep",
+        position: 1,
+        name: isEn ? "Map who has a pass and who is still hunting" : "Identifier qui a un pass et qui en cherche encore",
+        text: isEn
+          ? "Global Journey is sold out and the regular Worldwide sale closed in minutes — run a quick poll in the group to flag who is confirmed, who is on the official resale, and which weekend (W1 17-19 or W2 24-26 July) each person is targeting. Splitting across weekends changes everything: transport, accommodation, and whether you travel together at all."
+          : "Le Global Journey est sold out et la vente mondiale a fermé en minutes — lancez un sondage dans le groupe pour distinguer qui est confirmé, qui est sur la revente officielle, et quel week-end (W1 17-19 ou W2 24-26 juillet) chacun cible. Se répartir sur les deux week-ends change tout : transport, hébergement, et si vous partez ensemble ou non.",
+        url: `${SITE_URL}/${locale}/features/polls`,
+      },
+      {
+        "@type": "HowToStep",
+        position: 2,
+        name: isEn ? "Book Eurostar and accommodation before the next hike" : "Réserver Eurostar et hébergement avant la prochaine hausse",
+        text: isEn
+          ? "Paris-Brussels Eurostar at €30 advance creeps toward €100-150 on the festival Friday/Saturday and Monday return. Lock one outbound and one return for the whole crew, plus DreamVille if you have it or an Antwerp apartment within walking distance of Antwerpen-Centraal."
+          : "L'Eurostar Paris-Bruxelles à 30 € en avance grimpe vers 100-150 € sur le vendredi/samedi du festival et le retour du lundi. Verrouillez un même aller et un même retour pour la bande, plus DreamVille si vous l'avez ou un appartement à Anvers à pied d'Antwerpen-Centraal.",
+        url: `${SITE_URL}/${locale}/features/itinerary`,
+      },
+      {
+        "@type": "HowToStep",
+        position: 3,
+        name: isEn ? "Top up the Pearl float online and set a shared budget" : "Recharger le float Pearl en ligne et poser un budget partagé",
+        text: isEn
+          ? "Tickets and packages stay individual. Everything else (Eurostar, accommodation, taxis, restaurants in Antwerp before and after, Pearl top-ups) goes into a shared pool. Top up Pearls online to grab the 2-Pearl bonus per €100 and to skip the on-site queue."
+          : "Les billets et packages restent individuels. Le reste (Eurostar, hébergement, taxis, restos à Anvers avant et après, rechargements Pearl) va dans un pot commun. Rechargez vos Pearls en ligne pour récupérer le bonus de 2 Pearls par 100 € et éviter la file sur place.",
+        url: `${SITE_URL}/${locale}/features/budget`,
+      },
+      {
+        "@type": "HowToStep",
+        position: 4,
+        name: isEn ? "Plan the three days stage by stage" : "Planifier les trois jours scène par scène",
+        text: isEn
+          ? "16 stages, 500+ artists, clashes everywhere — share the schedule in advance so the group knows who is at the Mainstage for the closing set vs who is at Atmosphere or Core. Block transport-back-to-Antwerp into the timeline too: the last shuttles fill up fast after the closing acts."
+          : "16 scènes, plus de 500 artistes, des clashs partout — partagez la grille à l'avance pour que le groupe sache qui est à la Mainstage pour le closing vs qui est à Atmosphere ou Core. Bloquez aussi le retour vers Anvers dans la timeline : les dernières navettes se remplissent vite après les sets de fin.",
+      },
+    ],
+  };
+
+  return (
+    <>
+      <AuthorJsonLd />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(musicEventLd) }} />
+      <Nav navData={navData} navigationData={navigationData} />
+
+      <main className="min-h-screen bg-[#FFFBF5]">
+
+        {/* ━━━ HERO ━━━ */}
+        <section className="pt-[140px] lg:pt-[200px] pb-16 lg:pb-24 px-6 lg:px-12">
+          <div className="max-w-[900px] mx-auto">
+            <div className="hidden lg:block mb-8">
+              <Breadcrumb items={[
+                { label: isEn ? "Home" : "Accueil", href: `/${locale}` },
+                { label: isEn ? "Tomorrowland 2026 Trip Planner" : "Voyage Tomorrowland 2026" },
+              ]} />
+            </div>
+            <p className="font-nanum-pen text-[#F6391A] text-lg lg:text-xl mb-6">
+              {isEn ? "Festival guide & trip planner · Boom 2026" : "Guide du festival & planificateur · Boom 2026"}
+            </p>
+            <h1 className="text-[#001E13] text-[38px] lg:text-[72px] font-londrina-solid leading-[1.02] mb-6">
+              {isEn
+                ? "Tomorrowland 2026: Your Trip Planner to Boom"
+                : "Tomorrowland 2026 : Le Guide Voyage à Boom"}
+            </h1>
+            <p className="text-[#001E13]/70 text-lg lg:text-[22px] font-karla leading-[1.8] mb-6">
+              {isEn
+                ? <>Two weekends at De Schorre — 17 to 19 and 24 to 26 July 2026 — under the &apos;Consciencia&apos; banner. 500+ artists on 16 stages, with Calvin Harris making his Tomorrowland Belgium debut, plus David Guetta, Martin Garrix, Armin van Buuren and Hardwell. Global Journey is sold out worldwide and the regular sale cleared in under an hour — but the trip plan, the Antwerp apartment and the Pearl float are still yours to build. This is the complete guide to getting to Boom, where to sleep, how Pearls work, and how to keep the crew aligned across the festival days. If you&apos;re still picking your tools, see our <Link href={`/${locale}/blog/meilleures-applications-voyage-groupe`} className="text-[#F6391A] hover:underline font-semibold">comparison of group travel apps</Link>.</>
+                : <>Deux week-ends à De Schorre — du 17 au 19 et du 24 au 26 juillet 2026 — sous la bannière « Consciencia ». Plus de 500 artistes sur 16 scènes, avec Calvin Harris pour ses débuts à Tomorrowland Belgium, plus David Guetta, Martin Garrix, Armin van Buuren et Hardwell. Le Global Journey est sold out mondialement et la vente classique a fermé en moins d&apos;une heure — mais le plan voyage, l&apos;appartement à Anvers et le float Pearl restent à construire. Voici le guide complet pour rejoindre Boom, où dormir, comment marchent les Pearls, et comment garder la bande alignée pendant les jours de festival. Si vous hésitez encore entre les outils, jetez un œil à notre <Link href={`/${locale}/blog/meilleures-applications-voyage-groupe`} className="text-[#F6391A] hover:underline font-semibold">comparatif d&apos;applis de voyage en groupe</Link>.</>}
+            </p>
+            <p className="text-[#001E13]/50 text-sm font-karla mb-6">{isEn ? "9 min read" : "9 min de lecture"}</p>
+            <AuthorBio locale={locale} publishedDate="2026-05-13" modifiedDate="2026-05-13" />
+          </div>
+        </section>
+
+        {/* ━━━ KEY FACTS BOX ━━━ */}
+        <section className="pb-16 lg:pb-20 px-6 lg:px-12">
+          <div className="max-w-[1000px] mx-auto">
+            <div className="bg-white border border-[#001E13]/8 rounded-[24px] lg:rounded-[32px] p-6 lg:p-10">
+              <h2 className="text-[#001E13]/40 font-karla text-xs lg:text-sm uppercase tracking-[0.2em] mb-6">
+                {isEn ? "Festival facts" : "Les chiffres du festival"}
+              </h2>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-6 lg:gap-10">
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Weekends" : "Week-ends"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">{isEn ? "17-19 & 24-26 Jul" : "17-19 & 24-26 juil"}</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">2026</p>
+                </div>
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Site" : "Site"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">De Schorre</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">Boom, BE</p>
+                </div>
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Stages" : "Scènes"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">16</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">{isEn ? "500+ artists" : "500+ artistes"}</p>
+                </div>
+                <div>
+                  <p className="text-[#001E13]/50 font-karla text-xs uppercase tracking-wider mb-1">{isEn ? "Attendance" : "Affluence"}</p>
+                  <p className="text-[#001E13] font-londrina-solid text-2xl lg:text-3xl">~400k</p>
+                  <p className="text-[#001E13]/60 font-karla text-sm">{isEn ? "total" : "total"}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ THE STAKES ━━━ */}
+        <section className="pb-16 lg:pb-24 px-6 lg:px-12">
+          <div className="max-w-[900px] mx-auto space-y-8">
+            <p className="text-[#001E13]/75 text-lg lg:text-[22px] font-karla leading-[1.8]">
+              {isEn
+                ? "Two weekends of the most over-produced electronic festival on the planet, in a 75-hectare provincial park between Antwerp and Brussels. Tomorrowland 2026 lands under the 'Consciencia' theme — a meditative narrative that, in true Tomorrowland fashion, is mostly an excuse for an even more ambitious Mainstage. Calvin Harris makes his Tomorrowland Belgium debut, joining David Guetta, Martin Garrix, Armin van Buuren, Hardwell, the Chainsmokers, FISHER, John Summit and Sara Landry across 16 stages. The festival is strictly 18+, and the operation around the music — the Eurostar from Paris-Nord, the Pearl wristband, the DreamVille tent shared with five mates, the shuttle queue back to Antwerp at 4am — is what 70,000 people per day actually plan around."
+                : "Deux week-ends du festival électronique le plus over-produit de la planète, dans un parc provincial de 75 hectares entre Anvers et Bruxelles. Tomorrowland 2026 arrive sous le thème « Consciencia » — une narration méditative qui, fidèle à la maison, est surtout l'excuse à une Mainstage encore plus ambitieuse. Calvin Harris fait ses débuts au Tomorrowland Belgium, aux côtés de David Guetta, Martin Garrix, Armin van Buuren, Hardwell, des Chainsmokers, FISHER, John Summit et Sara Landry sur 16 scènes. Le festival est strictement +18, et l'opération autour de la musique — l'Eurostar depuis Paris-Nord, le bracelet Pearl, la tente DreamVille partagée à cinq, la file de navette retour à Anvers à 4h du matin — c'est autour de ça que 70 000 personnes par jour s'organisent vraiment."}
+            </p>
+            <p className="text-[#001E13] text-lg lg:text-[22px] font-karla font-bold leading-[1.8]">
+              {isEn
+                ? "WePlanify is the free shared command center for fans heading to Boom — Eurostar, DreamVille or Antwerp apartment, Pearl float, festival schedule and budget in one place, in English or French."
+                : "WePlanify, c'est le poste de commandement gratuit et partagé pour les fans qui descendent à Boom — Eurostar, DreamVille ou appartement à Anvers, float Pearl, grille du festival et budget au même endroit, en français ou anglais."}
+            </p>
+          </div>
+        </section>
+
+        {/* ━━━ TABLE OF CONTENTS ━━━ */}
+        <section className="px-6 lg:px-12">
+          <div className="max-w-[900px] mx-auto">
+            <ArticleTOC
+              title={isEn ? "On this page" : "Sur cette page"}
+              items={[
+                { id: "the-lineup", label: isEn ? "The 2026 lineup" : "L'affiche 2026" },
+                { id: "tickets", label: isEn ? "Tickets, Global Journey & resale" : "Billetterie, Global Journey & revente" },
+                { id: "getting-there", label: isEn ? "Getting to Boom" : "Rejoindre Boom" },
+                { id: "sleeping", label: isEn ? "DreamVille vs Antwerp vs Brussels" : "DreamVille vs Anvers vs Bruxelles" },
+                { id: "pearls", label: isEn ? "Pearls & on-site practicalities" : "Pearls & pratique sur site" },
+                { id: "planning", label: isEn ? "Planning the trip with the crew" : "Organiser le voyage entre potes" },
+                { id: "budget", label: isEn ? "Budget tips" : "Astuces budget" },
+                { id: "faq", label: isEn ? "Frequently asked questions" : "Questions fréquentes" },
+              ]}
+            />
+          </div>
+        </section>
+
+        {/* ━━━ THE LINEUP ━━━ */}
+        <FadeIn>
+          <section id="the-lineup" className="bg-[#001E13] py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[1000px] mx-auto">
+              <h2 className="text-[#FFFBF5] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "The 2026 Lineup" : "L'Affiche 2026"}
+              </h2>
+              <p className="text-[#FFFBF5]/50 font-karla text-base lg:text-lg mb-14 max-w-[700px]">
+                {isEn
+                  ? "16 stages, 500+ artists, two weekends. The headline arc and the names worth crossing a country for."
+                  : "16 scènes, plus de 500 artistes, deux week-ends. La ligne directrice des têtes d'affiche et les noms qui valent un voyage."}
+              </p>
+
+              <div className="space-y-0">
+                {(isEn
+                  ? [
+                      { stop: "Calvin Harris — Tomorrowland Belgium debut", desc: "The biggest announcement of the 2026 cycle. Calvin Harris has played the Brasil edition before but never Belgium — the Mainstage slot is the one the entire crowd will be in front of, no matter what is happening on the other 15 stages at the same time." },
+                      { stop: "The mainstream pillars", desc: "David Guetta, Martin Garrix, Armin van Buuren, Hardwell, The Chainsmokers, Dimitri Vegas & Like Mike — the festival's regulars. Predictable, but on Tomorrowland's Mainstage production, even the most-played sets look new again. Sebastian Ingrosso is also on the lineup, often Tomorrowland's preferred vehicle for an unofficial Swedish House Mafia moment." },
+                      { stop: "The techno and dubstep names", desc: "Sara Landry, REZZ, Subtronics, ILLENIUM, Miss Monique, Indira Paganotto. The Core, Atmosphere and other secondary stages run at a level that often outpunches the Mainstage on quality — the Tomorrowland trick is being willing to leave the headliner for these." },
+                      { stop: "The future and house anchors", desc: "FISHER, John Summit, NERVO, Marlon Hoffstadt, Chase & Status. The slots that fill the early evenings and define the energy curve of the day — arriving late means missing them and burning your peak window on the wrong set." },
+                      { stop: "The two weekends are not identical", desc: "Most headliners play both weekends, but secondary names and B2B sets often differ. Check the schedule per weekend before you finalise which one you target — Weekend 1 (17-19 July) and Weekend 2 (24-26 July) are not perfect copies of each other." },
+                    ]
+                  : [
+                      { stop: "Calvin Harris — premier Tomorrowland Belgium", desc: "La plus grosse annonce du cycle 2026. Calvin Harris a déjà joué l'édition Brasil mais jamais la Belgique — le créneau Mainstage, c'est celui devant lequel toute la foule sera, peu importe ce qu'il se passe sur les 15 autres scènes à la même heure." },
+                      { stop: "Les piliers grand public", desc: "David Guetta, Martin Garrix, Armin van Buuren, Hardwell, The Chainsmokers, Dimitri Vegas & Like Mike — les habitués de la maison. Prévisibles, mais sur la production Mainstage de Tomorrowland, même les sets les plus joués reprennent un coup de neuf. Sebastian Ingrosso est aussi à l'affiche, souvent le véhicule favori du festival pour un moment Swedish House Mafia officieux." },
+                      { stop: "Les pointures techno et dubstep", desc: "Sara Landry, REZZ, Subtronics, ILLENIUM, Miss Monique, Indira Paganotto. Le Core, Atmosphere et autres scènes secondaires tournent à un niveau qui dépasse souvent la Mainstage en qualité — la mécanique Tomorrowland, c'est accepter de quitter la tête d'affiche pour ces créneaux-là." },
+                      { stop: "Les ancrages future et house", desc: "FISHER, John Summit, NERVO, Marlon Hoffstadt, Chase & Status. Les créneaux qui remplissent les débuts de soirée et définissent la courbe d'énergie de la journée — arriver tard, c'est les rater et brûler son pic sur le mauvais set." },
+                      { stop: "Les deux week-ends ne sont pas identiques", desc: "La plupart des têtes d'affiche jouent les deux week-ends, mais les noms secondaires et les B2B diffèrent souvent. Vérifiez la grille par week-end avant de finaliser celui que vous visez — Week-end 1 (17-19 juillet) et Week-end 2 (24-26 juillet) ne sont pas des copies parfaites l'un de l'autre." },
+                    ]
+                ).map((item, i) => (
+                  <div key={i} className="flex gap-6 lg:gap-8">
+                    <div className="flex flex-col items-center flex-shrink-0">
+                      <div className="w-4 h-4 bg-[#F6391A] rounded-full" />
+                      {i < 4 && <div className="w-0.5 flex-1 bg-[#FFFBF5]/10" />}
+                    </div>
+                    <div className="pb-12 lg:pb-16">
+                      <h3 className="text-[#FFFBF5] text-xl lg:text-2xl font-londrina-solid mb-2">{item.stop}</h3>
+                      <p className="text-[#FFFBF5]/55 text-sm lg:text-base font-karla leading-[1.8]">{item.desc}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ TICKETS, GJ & RESALE ━━━ */}
+        <section id="tickets" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24 bg-[#FFFBF5]">
+          <div className="max-w-[1000px] mx-auto">
+            <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+              {isEn ? "Tickets, Global Journey & Official Resale" : "Billetterie, Global Journey & Revente Officielle"}
+            </h2>
+            <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-10 max-w-[700px]">
+              {isEn
+                ? "The sale calendar already happened — the only path forward is the official resale platform. Everything else is a refused gate scan."
+                : "Le calendrier de vente est passé — le seul chemin restant, c'est la plateforme de revente officielle. Le reste, c'est un scan d'entrée refusé."}
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Channel 1" : "Canal 1"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Global Journey (sold out)" : "Global Journey (sold out)"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "Bundles flight or train, hotel in Brussels or Antwerp, festival pass and daily shuttle. Sold out worldwide on 17 January 2026 — the only return path is people cancelling, and there is no public waiting list. Watch the official portal." : "Bundle vol ou train, hôtel à Bruxelles ou Anvers, pass festival et navette quotidienne. Sold out mondialement le 17 janvier 2026 — le seul retour, c'est des annulations, et il n'y a pas de liste d'attente publique. Surveillez le portail officiel."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Channel 2" : "Canal 2"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Official ticket resale" : "Revente billet officielle"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "Day passes (from €138) and Full Madness weekend passes (from €304 pre-sale, €365 worldwide) — the regular sales closed late January. The Tomorrowland official resale platform is the only legitimate secondary market. Listings appear sporadically, including the week of the festival." : "Pass jour (à partir de 138 €) et Full Madness week-end (à partir de 304 € pré-vente, 365 € vente mondiale) — les ventes classiques ont fermé fin janvier. La plateforme officielle de revente Tomorrowland est le seul marché secondaire légitime. Des annonces apparaissent ponctuellement, y compris la semaine du festival."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "What to avoid" : "À éviter"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Unofficial resale" : "Revente parallèle"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "Telegram, Facebook marketplace, Vinted, Viagogo: counterfeit passes are routine and the Tomorrowland gate scan is strict. Tickets are nominative and tied to your name on the wristband — you cannot legally transfer outside the official channel." : "Telegram, Marketplace Facebook, Vinted, Viagogo : les faux pass sont monnaie courante et le scan d'entrée Tomorrowland est strict. Les billets sont nominatifs et liés à votre nom sur le bracelet — vous ne pouvez pas transférer légalement en dehors du canal officiel."}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ GETTING THERE ━━━ */}
+        <FadeIn>
+          <section id="getting-there" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[1000px] mx-auto">
+              <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "Getting to Boom" : "Rejoindre Boom"}
+              </h2>
+              <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-12 max-w-[700px]">
+                {isEn
+                  ? "Eurostar to Brussels-Midi, then SNCB train to Boom, then a free festival shuttle to the gates. Rail is the obvious choice from Paris, Lille and London."
+                  : "Eurostar jusqu'à Bruxelles-Midi, puis train SNCB jusqu'à Boom, puis navette festival gratuite jusqu'aux portes. Le train est l'évidence depuis Paris, Lille et Londres."}
+              </p>
+
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-10">
+                <div className="bg-[#001E13] rounded-[24px] p-8 lg:p-10">
+                  <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "From Paris" : "Depuis Paris"}</p>
+                  <h3 className="text-[#FFFBF5] text-3xl lg:text-4xl font-londrina-solid mb-6">Paris → Brussels → Boom</h3>
+                  <ul className="space-y-3 text-[#FFFBF5]/70 font-karla text-sm lg:text-base leading-[1.7]">
+                    <li>{isEn ? "→ Eurostar (ex-Thalys) from Paris-Nord to Brussels-Midi" : "→ Eurostar (ex-Thalys) depuis Paris-Nord vers Bruxelles-Midi"}</li>
+                    <li>{isEn ? "→ ~1h22 to Brussels-Midi, from ~€30 advance" : "→ ~1h22 jusqu'à Bruxelles-Midi, à partir de ~30 € en avance"}</li>
+                    <li>{isEn ? "→ SNCB train to Boom: every ~30 min, ~32 min ride, €6-10" : "→ Train SNCB vers Boom : toutes les ~30 min, ~32 min, 6-10 €"}</li>
+                    <li>{isEn ? "→ De Lijn bus from Antwerp Groenplaats: ~47 min, ~€4" : "→ Bus De Lijn depuis Antwerp Groenplaats : ~47 min, ~4 €"}</li>
+                    <li>{isEn ? "→ Free festival shuttle from Boom station to the gates" : "→ Navette festival gratuite de la gare de Boom aux portes"}</li>
+                  </ul>
+                </div>
+
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-8 lg:p-10">
+                  <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "From Lille, London or by plane" : "Depuis Lille, Londres ou en avion"}</p>
+                  <h3 className="text-[#001E13] text-3xl lg:text-4xl font-londrina-solid mb-6">{isEn ? "Other routes" : "Autres routes"}</h3>
+                  <ul className="space-y-3 text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.7]">
+                    <li>{isEn ? "→ Lille-Europe → Brussels-Midi: 35-50 min by Eurostar" : "→ Lille-Europe → Bruxelles-Midi : 35-50 min en Eurostar"}</li>
+                    <li>{isEn ? "→ London St Pancras → Brussels-Midi: ~1h55 direct" : "→ Londres St Pancras → Bruxelles-Midi : ~1h55 direct"}</li>
+                    <li>{isEn ? "→ Brussels Zaventem (BRU): 33 km / ~20 min by road" : "→ Bruxelles-Zaventem (BRU) : 33 km / ~20 min par la route"}</li>
+                    <li>{isEn ? "→ Antwerp Airport (ANR): closer but fewer connections" : "→ Aéroport d'Anvers (ANR) : plus proche mais moins desservi"}</li>
+                    <li>{isEn ? "→ Last trains from Boom end before the closing set — plan a hotel near the festival or a taxi" : "→ Les derniers trains depuis Boom partent avant le set de clôture — prévoyez hôtel proche ou taxi"}</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ WHERE TO SLEEP ━━━ */}
+        <section id="sleeping" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24 bg-[#FFFBF5]">
+          <div className="max-w-[1000px] mx-auto">
+            <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+              {isEn ? "DreamVille vs Antwerp vs Brussels" : "DreamVille vs Anvers vs Bruxelles"}
+            </h2>
+            <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-10 max-w-[700px]">
+              {isEn
+                ? "Three real options once Global Journey is off the table. The right one depends on whether you trade comfort for proximity."
+                : "Trois vraies options une fois le Global Journey hors jeu. La bonne dépend de si vous échangez confort contre proximité."}
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Option 1" : "Option 1"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">DreamVille</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "On-site, walking distance to the gates, open 5 days from Thursday ~11:00 to Monday. Tiers from Magnificent Greens BYO tent to Solara (new 2026, with power outlets) and Marivela (A/C + private bathroom) above €2,700 per person. The actual Tomorrowland experience — if you can still find a slot through resale." : "Sur le site, à pied des portes, ouvert 5 jours du jeudi vers 11h au lundi. Niveaux de Magnificent Greens (tente perso) à Solara (nouveauté 2026, avec prises) et Marivela (clim + salle de bain privée) au-dessus de 2 700 € par personne. L'expérience Tomorrowland authentique — si vous trouvez encore un créneau sur la revente."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Option 2" : "Option 2"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Antwerp" : "Anvers"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "20 km north, 30 min train to Boom, hotels €150-400/night during festival weekends. The best base if you want real food, real bars and a shower that works after each day. Book within walking distance of Antwerpen-Centraal — the 6am train back from Boom is not a pleasant taxi negotiation." : "20 km au nord, 30 min de train jusqu'à Boom, hôtels 150-400 €/nuit sur les week-ends festival. La meilleure base si vous voulez vraie bouffe, vrais bars et une douche qui marche après chaque journée. Réservez à pied d'Antwerpen-Centraal — le train de 6h depuis Boom n'est pas une négociation taxi agréable."}
+                </p>
+              </div>
+              <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6">
+                <p className="font-nanum-pen text-[#F6391A] text-base mb-2">{isEn ? "Option 3" : "Option 3"}</p>
+                <h3 className="text-[#001E13] font-londrina-solid text-xl mb-3">{isEn ? "Brussels" : "Bruxelles"}</h3>
+                <p className="text-[#001E13]/70 font-karla text-sm leading-[1.7]">
+                  {isEn ? "30 km south, broader hotel inventory and better airport connections (BRU is 20 min from Brussels). The commute to Boom is longer (~45 min) but Brussels often has rooms when Antwerp is fully booked. Worth checking if your flight lands at BRU." : "30 km au sud, offre hôtelière plus large et meilleures connexions aéroport (BRU à 20 min de Bruxelles). Le trajet vers Boom est plus long (~45 min) mais Bruxelles a souvent des chambres quand Anvers est complet. À vérifier si votre vol atterrit à BRU."}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ PEARLS & PRACTICALITIES ━━━ */}
+        <FadeIn>
+          <section id="pearls" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[1000px] mx-auto">
+              <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "Pearls & On-Site Practicalities" : "Pearls & Pratique sur Site"}
+              </h2>
+              <p className="text-[#001E13]/60 font-karla text-base lg:text-lg mb-12 max-w-[700px]">
+                {isEn
+                  ? "Tomorrowland's currency is the Pearl — €1.82 each, only sold by the festival, only spent on the festival. Plan the float in advance or the queue eats your set."
+                  : "La monnaie Tomorrowland, c'est le Pearl — 1,82 € l'unité, vendu uniquement par le festival, dépensé uniquement au festival. Anticipez le float ou la file mangera votre set."}
+              </p>
+
+              <div className="space-y-6">
+                <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6 lg:p-8">
+                  <h3 className="text-[#001E13] font-londrina-solid text-xl lg:text-2xl mb-3">{isEn ? "How the Pearl system works" : "Comment marche le Pearl"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.8]">
+                    {isEn
+                      ? "€20 buys 11 Pearls — about €1.82 each. Top up online before arriving: every €100 in online top-up earns a 2-Pearl bonus, and unspent Pearls are auto-refunded after the festival. On-site top-ups work too, but the unspent balance has to be claimed manually before the announced deadline. Keep one person in the group in charge of the Pearl float and rotate the rounds."
+                      : "20 € achètent 11 Pearls — environ 1,82 € l'unité. Rechargez en ligne avant d'arriver : chaque 100 € en ligne donne un bonus de 2 Pearls, et le solde non utilisé est remboursé automatiquement après. Le rechargement sur place marche aussi, mais le solde non utilisé doit être réclamé manuellement avant la deadline. Désignez une personne du groupe responsable du float Pearl et faites tourner les tournées."}
+                  </p>
+                </div>
+                <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6 lg:p-8">
+                  <h3 className="text-[#001E13] font-londrina-solid text-xl lg:text-2xl mb-3">{isEn ? "Banned items & DreamVille rules" : "Interdictions & règles DreamVille"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.8]">
+                    {isEn
+                      ? "No glass, no weapons, no drugs, no pets, no fire-starting items, no outside food or drink on the main grounds. DreamVille is more permissive: each camper can bring 12 beers, 12 soft drinks, 12 bottles of water and non-perishable food. Check the latest list on the official site before packing — the rules tighten year by year."
+                      : "Pas de verre, pas d'armes, pas de drogue, pas d'animaux, pas d'objets feu, pas de bouffe ou boisson extérieure sur les zones principales. DreamVille est plus permissif : chaque campeur peut amener 12 bières, 12 sodas, 12 bouteilles d'eau et de la bouffe non périssable. Vérifiez la dernière liste sur le site officiel avant de faire le sac — les règles se durcissent d'année en année."}
+                  </p>
+                </div>
+                <div className="bg-white border border-[#001E13]/10 rounded-2xl p-6 lg:p-8">
+                  <h3 className="text-[#001E13] font-londrina-solid text-xl lg:text-2xl mb-3">{isEn ? "Weather late July in Boom" : "Météo fin juillet à Boom"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm lg:text-base leading-[1.8]">
+                    {isEn
+                      ? "Average high 23°C, low 15°C. Rain falls on roughly 12 days per month — a ~27% daily chance during the festival. Belgian summer flips between heatwave and downpour from one day to the next, so pack both a sunscreen kit and a rain poncho. Sturdy waterproof shoes for the DreamVille mud after a heavy shower."
+                      : "Maxi moyen 23°C, mini 15°C. Il pleut environ 12 jours par mois — ~27 % de chance quotidienne pendant le festival. L'été belge oscille entre canicule et averse d'un jour à l'autre, donc emportez à la fois crème solaire et poncho. Des chaussures imperméables solides pour la boue DreamVille après une grosse pluie."}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ PLANNING THE TRIP ━━━ */}
+        <section id="planning" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24 bg-[#FFFBF5]">
+          <div className="max-w-[900px] mx-auto space-y-8">
+            <h2 className="text-[#001E13] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08]">
+              {isEn ? "Planning the Trip with the Crew" : "Organiser le Voyage entre Potes"}
+            </h2>
+            <p className="text-[#001E13]/75 text-lg lg:text-[22px] font-karla leading-[1.8]">
+              {isEn
+                ? <>The two-weekend split makes Tomorrowland trickier than a single-weekend festival: half the group might end up on Weekend 1, the other half on Weekend 2, with different transport, different accommodation, sometimes different stages. Run a quick <Link href={`/${locale}/features/polls`} className="text-[#F6391A] hover:underline font-semibold">group poll</Link> early to lock who is on which weekend, who is at DreamVille vs Antwerp, and who is taking the Eurostar together. The poll is the smallest piece of work that prevents 80% of the festival arguments.</>
+                : <>La répartition deux week-ends rend Tomorrowland plus délicat qu&apos;un festival sur un seul week-end : la moitié du groupe peut finir sur le Week-end 1, l&apos;autre sur le Week-end 2, avec transports différents, hébergements différents, parfois scènes différentes. Lancez un <Link href={`/${locale}/features/polls`} className="text-[#F6391A] hover:underline font-semibold">sondage de groupe</Link> tôt pour caler qui est sur quel week-end, qui dort à DreamVille vs Anvers, et qui prend l&apos;Eurostar ensemble. Le sondage, c&apos;est le plus petit travail qui évite 80 % des engueulades du festival.</>}
+            </p>
+            <p className="text-[#001E13]/75 text-lg lg:text-[22px] font-karla leading-[1.8]">
+              {isEn
+                ? <>The <Link href={`/${locale}/features/itinerary`} className="text-[#F6391A] hover:underline font-semibold">shared itinerary</Link> is where the band clashes live. Pin the must-sees (Calvin Harris on Mainstage, the closing set you cannot miss) and let the group fork on the others — Tomorrowland is built so that nobody should feel guilty for leaving the Mainstage for Core or Atmosphere. The itinerary also stores the meeting points (Mainstage flag pole, food hall entrance, DreamVille section name) when the network drops.</>
+                : <>L&apos;<Link href={`/${locale}/features/itinerary`} className="text-[#F6391A] hover:underline font-semibold">itinéraire partagé</Link>, c&apos;est là que vivent les clashs entre groupes. Épinglez les indispensables (Calvin Harris à la Mainstage, le set de clôture à ne pas rater) et laissez le groupe se diviser sur le reste — Tomorrowland est conçu pour que personne ne culpabilise de quitter la Mainstage pour Core ou Atmosphere. L&apos;itinéraire stocke aussi les points de rendez-vous (mât drapeau Mainstage, entrée food hall, nom de secteur DreamVille) quand le réseau lâche.</>}
+            </p>
+          </div>
+        </section>
+
+        {/* ━━━ BUDGET TIPS ━━━ */}
+        <FadeIn>
+          <section id="budget" className="bg-[#001E13] py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+            <div className="max-w-[900px] mx-auto space-y-8">
+              <h2 className="text-[#FFFBF5] text-[28px] lg:text-[48px] font-londrina-solid leading-[1.08] mb-4">
+                {isEn ? "Budget Tips" : "Astuces Budget"}
+              </h2>
+              <p className="text-[#FFFBF5]/65 text-lg lg:text-[22px] font-karla leading-[1.8]">
+                {isEn
+                  ? <>Tickets, DreamVille and Global Journey packages are individual — keep them out of the shared pool. The shared pool is for transport (Eurostar, SNCB, shuttle), accommodation outside DreamVille, restaurants in Antwerp before and after, and the on-site Pearl float. Set up a <Link href={`/${locale}/features/budget`} className="text-[#EEF899] hover:underline font-semibold">shared budget tracker</Link> with one category per cost type, and add an explicit &apos;Pearl float&apos; line so the bar and food rounds don&apos;t disappear into a generic &apos;misc&apos; column.</>
+                  : <>Les billets, DreamVille et packages Global Journey sont individuels — gardez-les hors du pot commun. Le pot commun, c&apos;est pour le transport (Eurostar, SNCB, navette), l&apos;hébergement hors DreamVille, les restos à Anvers avant et après, et le float Pearl sur place. Mettez en place un <Link href={`/${locale}/features/budget`} className="text-[#EEF899] hover:underline font-semibold">suivi de budget partagé</Link> avec une catégorie par type de dépense, et ajoutez une ligne explicite « float Pearl » pour que les tournées et la bouffe ne se perdent pas dans une colonne « divers ».</>}
+              </p>
+              <p className="text-[#FFFBF5]/65 text-lg lg:text-[22px] font-karla leading-[1.8]">
+                {isEn
+                  ? "Eurostar prices climb fast on the Friday outbound and Sunday/Monday return. Off-peak windows (very early morning Friday departure, mid-Monday return) are still bookable at advance fares. Booking the full crew on the same train trims both cost and chaos at Brussels-Midi when the SNCB connection is only minutes away."
+                  : "Les prix Eurostar grimpent vite sur le vendredi aller et le dimanche/lundi retour. Les créneaux off-peak (très tôt le vendredi matin, milieu de lundi pour le retour) restent réservables aux tarifs avancés. Réserver toute la bande sur le même train fait économiser à la fois en argent et en chaos à Bruxelles-Midi quand la correspondance SNCB est à quelques minutes seulement."}
+              </p>
+              <p className="text-[#FFFBF5]/65 text-lg lg:text-[22px] font-karla leading-[1.8]">
+                {isEn
+                  ? "On-site Pearls are the silent budget killer. Bar rounds, food, merch — a typical Tomorrowland day ends around €80-120 per person on the wristband even on a moderate run. Top up online to grab the 2-Pearl bonus per €100 and skip the on-site queue, but top up €30 less than you think you need: an extra reload mid-festival takes 10 minutes, while a giant post-festival refund is money you didn't have during the weekend."
+                  : "Le Pearl sur place, c'est le tueur silencieux du budget. Tournées, bouffe, merch — une journée Tomorrowland moyenne sort à 80-120 € par personne sur le bracelet même sur un rythme tranquille. Rechargez en ligne pour récupérer le bonus de 2 Pearls par 100 € et éviter la file sur place, mais rechargez 30 € de moins que ce que vous estimez : un rechargement à mi-parcours prend 10 minutes, alors qu'un gros remboursement post-festival, c'est de l'argent que vous n'aviez pas pendant le week-end."}
+              </p>
+            </div>
+          </section>
+        </FadeIn>
+
+        {/* ━━━ FAQ ━━━ */}
+        <section id="faq" className="py-20 lg:py-28 px-6 lg:px-12 scroll-mt-24">
+          <div className="max-w-[800px] mx-auto">
+            <h2 className="text-3xl lg:text-5xl font-londrina-solid text-[#001E13] mb-10 text-center">
+              {isEn ? "Frequently Asked Questions" : "Questions Fréquemment Posées"}
+            </h2>
+            <div className="space-y-6">
+              {faqItems.map((item, i) => (
+                <details key={i} className="group border-b border-[#001E13]/10 pb-5">
+                  <summary className="flex items-start justify-between cursor-pointer list-none font-karla font-semibold text-[#001E13] text-base lg:text-lg">
+                    <span className="pr-4">{item.q}</span>
+                    <span className="text-[#F6391A] text-xl leading-none mt-0.5 group-open:rotate-45 transition-transform">+</span>
+                  </summary>
+                  <p className="mt-3 text-[#001E13]/70 text-sm lg:text-base font-karla leading-relaxed">{item.a}</p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ DISCOVER MORE ━━━ */}
+        <section className="py-12 lg:py-16 px-6 lg:px-12 bg-[#FFFBF5]">
+          <div className="max-w-[1200px] mx-auto">
+            <h2 className="text-2xl lg:text-4xl font-londrina-solid text-[#001E13] text-center mb-10">{isEn ? "Discover More" : "Découvrir aussi"}</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              <Link href={`/${locale}/hellfest-2026-trip-planner`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Hellfest 2026 Trip Planner" : "Voyage Hellfest 2026"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "Four days of metal in Clisson, France." : "Quatre jours de metal à Clisson."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read more →" : "En savoir plus →"}</span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/champions-league-final-2026-psg-arsenal`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Champions League Final" : "Finale Ligue des Champions"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "PSG vs Arsenal in Budapest." : "PSG vs Arsenal à Budapest."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read more →" : "En savoir plus →"}</span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/trip-with-friends`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Trip with Friends" : "Voyage entre Amis"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "Plan any group trip effortlessly." : "Organisez n'importe quel voyage de groupe."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read more →" : "En savoir plus →"}</span>
+                </div>
+              </Link>
+              <Link href={`/${locale}/guides/plan-group-trip`} className="group">
+                <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 lg:p-8 hover:shadow-lg transition-shadow h-full">
+                  <h3 className="text-lg lg:text-xl font-londrina-solid text-[#001E13] mb-2">{isEn ? "Group Trip Guide" : "Guide Voyage de Groupe"}</h3>
+                  <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">{isEn ? "The complete step-by-step guide." : "Le guide complet étape par étape."}</p>
+                  <span className="text-[#F6391A] font-karla font-bold text-sm group-hover:underline">{isEn ? "Read the guide →" : "Lire le guide →"}</span>
+                </div>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* ━━━ CTA ━━━ */}
+        <section className="py-16 lg:py-24 px-6 lg:px-12">
+          <div className="max-w-[1200px] mx-auto">
+            <div className="bg-gradient-to-br from-[#F6391A] to-[#d42d10] rounded-[24px] lg:rounded-[40px] p-8 lg:p-16 text-center">
+              <h2 className="text-3xl lg:text-5xl font-londrina-solid text-[#FFFBF5] mb-4">
+                {isEn ? "Build Your Tomorrowland Trip" : "Construisez Votre Voyage Tomorrowland"}
+              </h2>
+              <p className="text-[#FFFBF5]/80 font-karla text-base lg:text-lg max-w-2xl mx-auto mb-8 leading-relaxed">
+                {isEn ? "Eurostar, DreamVille or Antwerp apartment, Pearl float, festival schedule, shared budget — one plan, your whole crew on the same page." : "Eurostar, DreamVille ou appartement à Anvers, float Pearl, grille du festival, budget partagé — un seul plan, toute votre bande alignée."}
+              </p>
+              <div className="flex justify-center">
+                <Link href={`https://app.weplanify.com/${locale}/register?utm_source=landing&utm_campaign=tomorrowland-2026&template=tomorrowland-2026`}>
+                  <PulsatingButton className="font-karla font-bold">{isEn ? "Start planning" : "Commencer"}</PulsatingButton>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+      </main>
+      <Footer footerData={footerData} />
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -42,7 +42,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
 
     // Use case pages for each locale
-    const useCasePages = ["trip-with-friends", "bachelorette-trip", "family-trip", "road-trip", "team-building", "school-trip", "world-cup-2026-trip-planner", "champions-league-final-2026-psg-arsenal", "alternatives", "alternatives/wanderlog", "alternatives/squadtrip", "alternatives/tripit", "alternatives/cruzmi", "alternatives/best-group-trip-planner-apps", "alternatives/stippl"];
+    const useCasePages = ["trip-with-friends", "bachelorette-trip", "family-trip", "road-trip", "team-building", "school-trip", "world-cup-2026-trip-planner", "champions-league-final-2026-psg-arsenal", "hellfest-2026-trip-planner", "tomorrowland-2026-trip-planner", "solar-eclipse-2026-trip-planner", "alternatives", "alternatives/wanderlog", "alternatives/squadtrip", "alternatives/tripit", "alternatives/cruzmi", "alternatives/best-group-trip-planner-apps", "alternatives/stippl"];
     for (const locale of locales) {
       for (const page of useCasePages) {
         entries.push({


### PR DESCRIPTION
Hellfest (18-21 June), Tomorrowland (17-19 & 24-26 July) and Solar Eclipse (12 August) — each ~600 lines, EN+FR, with BreadcrumbList, Article, FAQPage, HowTo and event-specific JSON-LD (MusicFestival or Event), cross-linked via Discover More to the existing PSG and World Cup pages. Sitemap updated.