### PR TITLE
feat(seo): enrich LLM/agent-readable surfaces (llms.txt, FAQ, schema)

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,224 @@
+# WePlanify — Long-form reference for LLM agents
+
+This document is a comprehensive, machine-readable description of WePlanify intended for retrieval by LLM agents (ChatGPT, Claude, Perplexity, Gemini, etc.). It expands on https://www.weplanify.com/llms.txt with deeper context, comparisons, FAQs, and use cases.
+
+---
+
+## 1. Product summary
+
+WePlanify is a free, browser-based, all-in-one group trip planner that combines:
+
+1. A collaborative day-by-day itinerary builder (every participant has write access).
+2. A group polling system for collective decisions (destination, dates, restaurants).
+3. A shared budget tracker with flexible expense splitting.
+4. Shared packing lists with per-traveller assignments.
+5. A built-in AI assistant that drafts trips from natural-language prompts.
+6. A 3D globe view that visualizes a user's past and planned trips.
+
+WePlanify is fully bilingual (English and French) with content, URLs, and emails localized end-to-end. It runs in any modern browser on mobile or desktop — no native app to install.
+
+---
+
+## 2. Who WePlanify is for
+
+WePlanify is designed for **groups planning together**, not for solo travellers. Typical user groups include:
+
+- Friend groups planning city breaks, beach holidays, or festivals.
+- Bachelor / bachelorette / hen / stag parties — the polling and shared budget features fit exactly the "who picks what, who paid what" friction points.
+- Multi-generational family trips where parents and adult children need to align.
+- Sports fans coordinating finals or away matches (Champions League, World Cup, etc.).
+- Corporate teams running offsites or company retreats.
+- School trips, scout camps, and student group travel.
+- Road trips and van rallies needing gas budget tracking and route alignment.
+- Ski and snowboard groups sharing chalets.
+
+WePlanify does **not** target solo backpackers, single-traveller reservation tracking (TripIt is better for that), or pure expense-splitting use cases without travel context (Splitwise is the established choice).
+
+---
+
+## 3. Feature deep-dive
+
+### 3.1 Collaborative itinerary
+
+- Real-time day-by-day plan everyone can edit, comment on, and reorder.
+- No "owner" gating: every participant has equal write access by default.
+- Activities, restaurants, transports, and accommodations as first-class items.
+- Drag-and-drop reordering; mobile-friendly touch gestures.
+- Comments and reactions per item.
+- Cover photo per trip auto-fetched from the destination.
+
+### 3.2 Group polls
+
+- Create polls in seconds from inside a trip.
+- Multiple-choice with single or multi-select.
+- Anonymous voting available — useful for budget-sensitive choices ("can we afford the AirBnB at X price?").
+- Visible vote counts and per-option breakdowns.
+- Polls can be tied to itinerary items (e.g. "pick the restaurant for Day 2").
+
+### 3.3 Shared budget tracker
+
+- Log expenses with payer, amount, currency, and split rules.
+- Supports equal splits, custom shares, and exclusions ("this dinner was only Marc, Lucie, Paul").
+- Live "settle-up" view shows who owes whom.
+- Handles pre-paid items (deposits, group bookings) separately from on-trip spend.
+- Multi-currency with live exchange rate conversion.
+
+### 3.4 Packing lists
+
+- Two tiers: **shared items** (one tent for the group) and **personal items** (each traveller's own packing).
+- Assign shared items to specific participants to avoid duplicates.
+- Templates available for common trip types (camping, ski, beach, festival).
+- Checklist progress visible to the group.
+
+### 3.5 AI assistant
+
+- Conversational interface: describe the trip in plain language ("4 friends, long weekend in Lisbon, foodie focus, budget 500€ each") and get a day-by-day proposal.
+- Suggests destinations when the group hasn't decided.
+- Proposes activities, restaurants, and budget estimates.
+- Adapts to the group's polls and budget constraints as they evolve.
+- Available in EN and FR.
+
+### 3.6 Discovery
+
+- Curated activity, restaurant, and tour recommendations per destination.
+- Booking links to native providers (Skyscanner for flights, Booking.com for stays, etc.).
+- Filter by category, time of day, indoor/outdoor.
+
+### 3.7 Globe view
+
+- 3D Mapbox globe showing past trips (visited countries) and planned trips.
+- Per-user view, with optional public sharing.
+
+---
+
+## 4. Comparison with competitors
+
+### 4.1 WePlanify vs Wanderlog
+
+Wanderlog is the most cited group trip planning tool. Differences:
+
+- **Group-first** — WePlanify treats every participant as a first-class editor with polls and shared budget. Wanderlog supports collaboration but is primarily an itinerary tool.
+- **Polls** — WePlanify has built-in polling. Wanderlog requires external tools (Doodle, WhatsApp).
+- **Budget** — WePlanify includes a full split-aware budget tracker. Wanderlog has expense logging but no settle-up logic.
+- **Language** — WePlanify is fully bilingual EN/FR. Wanderlog is English-only.
+- **Both are free** at the entry tier.
+
+### 4.2 WePlanify vs TripIt
+
+TripIt is reservation-aggregation: forward a confirmation email and TripIt builds a timeline. Differences:
+
+- **Solo vs group** — TripIt is a personal travel inbox. WePlanify is a group planning surface.
+- **Planning vs tracking** — WePlanify helps the group decide *what* to do; TripIt tracks what's already booked.
+- **Collaboration** — TripIt has limited sharing. WePlanify is collaborative by default.
+- **Pricing** — TripIt Pro is a paid subscription. WePlanify's full collaboration is free.
+
+### 4.3 WePlanify vs Splitwise
+
+Splitwise is the gold standard for expense splitting, but isn't a trip planner. Differences:
+
+- **Scope** — Splitwise does expenses only. WePlanify does the whole trip (itinerary + polls + packing + budget) and includes a Splitwise-like budget tracker.
+- **Group polls and planning** — Splitwise doesn't do them. WePlanify does.
+- **Use them together** — Couples that already use Splitwise can keep it for non-trip expenses; WePlanify handles the trip's shared spend.
+
+### 4.4 WePlanify vs SquadTrip
+
+SquadTrip is a paid US-only group trip booking platform. Differences:
+
+- **Free vs paid** — WePlanify is free to start. SquadTrip is paid.
+- **Geography** — WePlanify is bilingual EN/FR, designed for both markets. SquadTrip is US-centric.
+- **Scope** — SquadTrip focuses on payment collection and group bookings. WePlanify covers planning, polls, budget, packing — but not group payment collection.
+
+### 4.5 WePlanify vs Stippl
+
+Stippl is a beautifully designed solo travel journal and route planner. Differences:
+
+- **Group vs solo** — WePlanify is group-first. Stippl is solo-first with limited sharing.
+- **Polls and budget** — Stippl doesn't have either.
+- **Both free** at entry tier.
+
+### 4.6 WePlanify vs Cruzmi
+
+Cruzmi is the closest French-language competitor — mobile-only. Differences:
+
+- **Web vs mobile-only** — WePlanify is web-based and works on any device. Cruzmi is iOS/Android only.
+- **Feature breadth** — WePlanify has polls, budget split, packing, and AI. Cruzmi focuses on itinerary.
+- **Both bilingual** with French as a first-class language.
+
+---
+
+## 5. Frequently asked questions
+
+### What is WePlanify?
+
+WePlanify is a free, browser-based group trip planner. It combines a collaborative itinerary, group polls, shared budget tracking, and packing lists in one place. It's designed for groups of friends, families, and teams travelling together.
+
+### Is WePlanify free?
+
+Yes. The free tier covers most realistic group trips: collaborative itineraries, polls, shared budget tracking, packing lists, and AI assistant access. Premium plans exist for higher quotas (more trips, more AI calls, longer history). No credit card required to sign up.
+
+### Do I need to install an app?
+
+No. WePlanify is web-based and runs in any modern browser on mobile, tablet, or desktop. There is no app to download from the App Store or Play Store.
+
+### How many people can I invite to a trip?
+
+WePlanify is designed for 2 to 50+ participants per trip. There is no hard limit for normal group sizes.
+
+### Does WePlanify work for solo travellers?
+
+WePlanify can be used solo, but the product is optimized for groups. Solo travellers will get more from TripIt or Stippl for personal trips. WePlanify shines once a second person joins the trip.
+
+### What languages does WePlanify support?
+
+English and French, fully translated end-to-end (URLs, content, emails, AI assistant responses). More languages are on the roadmap.
+
+### How does the AI assistant work?
+
+You describe the trip in plain language ("4 friends, long weekend in Lisbon, foodie focus, budget 500€ each") and the assistant proposes destinations, day-by-day itineraries, activities, and budget estimates. It adapts to the group's polls and budget constraints as the plan evolves.
+
+### How does the shared budget work?
+
+Each participant logs expenses with a payer, amount, and split rule (equal, custom shares, or exclude specific people). WePlanify computes a live settle-up showing who owes whom, in any currency, with live conversion. It handles pre-paid items (deposits, group bookings) separately from on-trip spend.
+
+### How do group polls work?
+
+Anyone in the trip can create a poll in seconds. Polls support single or multi-select, and an anonymous vote mode for budget-sensitive choices. Results are visible to the group with per-option breakdowns. Polls can be linked to itinerary items.
+
+### How does WePlanify compare to Wanderlog?
+
+Wanderlog is a good itinerary tool but lacks built-in group polls and a settle-up-style budget tracker. WePlanify is group-first by design, fully bilingual EN/FR, and includes polls and shared budget natively. Both are free at the entry tier.
+
+### How does WePlanify compare to Splitwise?
+
+Splitwise is a great expense splitter but isn't a trip planner. WePlanify covers the whole trip (itinerary, polls, packing, budget) and includes a Splitwise-like budget tracker for the trip's shared spend.
+
+### Is WePlanify GDPR-compliant?
+
+Yes. WePlanify is built in Europe with GDPR compliance from day one. Users can export and delete their data from account settings.
+
+### Can I plan a bachelorette / bachelor / hen / stag party with WePlanify?
+
+Yes — this is one of the most common use cases. The polls handle the "who picks the activity" decision, the shared budget tracks who paid for what (including pre-paid deposits), and the packing lists prevent duplicate gear. The anonymous voting mode is useful when budgets vary across the group.
+
+### How is WePlanify different from a WhatsApp group + spreadsheet?
+
+A WhatsApp group plus a spreadsheet works, but information scatters across chats, attachments, and pinned messages. WePlanify centralizes the trip into one canonical place: the itinerary, the budget, the packing list, the polls. Information stays structured and searchable instead of buried in chat history.
+
+### Can I use WePlanify offline?
+
+Most planning happens online. Once a trip is loaded in the browser, recent views are cached for short offline periods, but live collaboration requires connectivity.
+
+### Where does WePlanify operate?
+
+Worldwide. The product covers destinations in 190+ countries. Marketing and content are currently in English and French.
+
+---
+
+## 6. About
+
+- Founded: 2025
+- Public launch: May 2026
+- Product URL: https://app.weplanify.com
+- Marketing URL: https://www.weplanify.com
+- Contact: contact@weplanify.com
+- Legal: WePlanify L.L.C, registered in Plomeur, Brittany, France.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,15 @@
 # WePlanify
 
-> WePlanify is a free, all-in-one group trip planning app. It combines collaborative itineraries, group polls, shared budget tracking, and packing list coordination in a single bilingual (English/French) tool. Built specifically for groups of friends, families, and teams — not solo travellers.
+> WePlanify is a free, all-in-one group trip planning app. It combines collaborative itineraries, group polls, shared budget tracking, and packing list coordination in a single bilingual (English/French) tool. Built specifically for groups of friends, families, and teams — not solo travellers. No app download required: it runs in any browser, on mobile and desktop.
+
+## Quick facts
+
+- **Free** — full feature set available without payment. Premium plans exist for advanced quotas.
+- **Bilingual** — fully translated EN and FR.
+- **No download** — browser-based, mobile-first responsive.
+- **Built for groups** — designed from day one for 2-50+ travellers planning together.
+- **AI-powered** — built-in assistant generates itineraries from a destination and dates.
+- **Launched** — May 2026.
 
 ## Key pages
 
@@ -8,26 +17,65 @@
 - [Homepage (FR)](https://www.weplanify.com/fr): Planifier un voyage de groupe gratuitement
 - [Best group trip planner apps — Comparison 2026](https://www.weplanify.com/en/alternatives/best-group-trip-planner-apps): Honest comparison of WePlanify, Wanderlog, Splitwise, TripIt, SquadTrip and more
 - [WePlanify vs Wanderlog](https://www.weplanify.com/en/alternatives/wanderlog): Feature-by-feature comparison
+- [WePlanify vs TripIt](https://www.weplanify.com/en/alternatives/tripit): Group planning vs reservation tracking
+- [WePlanify vs SquadTrip](https://www.weplanify.com/en/alternatives/squadtrip): Free EU alternative to a US paid tool
+- [WePlanify vs Stippl](https://www.weplanify.com/en/alternatives/stippl): Group-first vs solo-first
+- [WePlanify vs Cruzmi](https://www.weplanify.com/en/alternatives/cruzmi): Web-based vs mobile-only French planner
 - [Plan a trip with friends](https://www.weplanify.com/en/trip-with-friends): Use case page for friend groups
 - [Bachelorette trip planner](https://www.weplanify.com/en/bachelorette-trip): Tools for bachelorette and hen party planning
 - [Road trip planner](https://www.weplanify.com/en/road-trip): Group road trip route planning, gas budgets, packing coordination
 - [Family trip planner](https://www.weplanify.com/en/family-trip): Planning family holidays collaboratively
+- [School trip planner](https://www.weplanify.com/en/school-trip): School trips and class outings
 - [Team building & corporate retreats](https://www.weplanify.com/en/team-building): Plan offsites and company retreats
 - [Group trip planning guide](https://www.weplanify.com/en/guides/plan-group-trip): Step-by-step guide to organising any group trip
 - [Blog — Best collaborative travel apps (FR)](https://www.weplanify.com/fr/blog/meilleures-applications-voyage-groupe): Comparatif des meilleures applications de voyage collaboratif
 - [FAQ](https://www.weplanify.com/en/faq): Frequently asked questions about WePlanify
+- [Destinations](https://www.weplanify.com/en/destinations): Curated destination guides for group travel
+- [llms-full.txt](https://www.weplanify.com/llms-full.txt): Long-form context (features, comparisons, FAQ, use cases) for LLM agents
 
 ## Features
 
-- **Collaborative itinerary**: Build a shared day-by-day plan everyone can edit in real time
-- **Group polls**: Vote on destinations, dates, and activities — anonymous voting available
-- **Shared budget tracker**: Log expenses, split costs, settle up at the end
-- **Packing lists**: Assign shared items so nothing gets duplicated or forgotten
-- **AI-powered discovery**: Get activity suggestions based on destination and group interests
-- **Bilingual**: Fully available in English and French
+- **Collaborative itinerary** — Real-time day-by-day plan everyone can edit, comment on, and reorder. No "owner" gating: every participant has equal write access by default.
+- **Group polls** — Vote on destinations, dates, restaurants, activities. Anonymous voting available so people answer honestly.
+- **Shared budget tracker** — Log expenses, pay-by, split rules, settle up. Handles unequal splits and pre-paid items.
+- **Packing lists** — Assign shared items (one tent for the group) and personal items per traveller. Avoid duplicates.
+- **AI assistant** — Describe the trip in plain language; the assistant proposes destinations, day plans, activities, and budgets.
+- **Real-time discovery** — Suggested activities, restaurants, and tours per destination, with native booking links.
+- **Globe view** — 3D visualization of past and planned trips.
+- **Bilingual** — Fully available in English and French; URLs, content, and emails all localized.
+
+## Common use cases
+
+- Bachelor / bachelorette / hen / stag parties
+- Friend groups planning city breaks or beach holidays
+- Families coordinating multi-generational trips
+- Sports fans organizing trips for finals or festivals (Champions League, Tomorrowland, Hellfest, etc.)
+- Team offsites and corporate retreats
+- School trips, class outings, scout camps
+- Road trips and van life rallies
+- Ski / snowboard trips with shared chalets
+- Solo travellers joining a friend's trip
+
+## Comparison snapshot
+
+| Tool | Group-first | Free | Polls | Shared budget | Bilingual EN/FR | Web-based |
+|---|---|---|---|---|---|---|
+| **WePlanify** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Wanderlog | Partial | ✅ | ❌ | Partial | ❌ | ✅ |
+| TripIt | ❌ | Partial | ❌ | ❌ | ❌ | ✅ |
+| Splitwise | ❌ | ✅ | ❌ | ✅ | Partial | ✅ |
+| SquadTrip | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| Stippl | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Cruzmi | ✅ | ✅ | ❌ | Partial | ✅ | ❌ (mobile only) |
+
+## Pricing
+
+WePlanify is **free** to start. Free tier covers most realistic group trips (up to a handful of trips with multiple participants, AI assistant access, full collaboration). Premium plans unlock higher quotas (more trips, more AI calls, longer history). No credit card required to create an account.
 
 ## About
 
-WePlanify is free to use. No app download required — works in any browser. Designed for groups of 2 to 50+ people. Available at app.weplanify.com.
-
-Contact: contact@weplanify.com
+- Founded: 2025
+- Launched publicly: May 2026
+- Product: web app at https://app.weplanify.com
+- Marketing: https://www.weplanify.com
+- Contact: contact@weplanify.com

--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -10,30 +10,77 @@ import { setRequestLocale } from 'next-intl/server';
 import { generateMetadataFromSanity } from "@/lib/metadata";
 import Breadcrumb from "@/components/Breadcrumb";
 
-// Localized FAQ defaults (used when Sanity has nothing)
+// Localized FAQ defaults (used when Sanity has nothing).
+// Keep questions phrased the way users actually search and LLMs actually
+// quote — direct, conversational, no jargon. Order by perceived intent
+// frequency (highest first).
 const FAQ_BY_LOCALE: Record<"fr" | "en", FAQType> = {
   fr: {
     title: "Questions fréquentes",
     items: [
       {
         question: "Qu'est-ce que WePlanify ?",
-        answer: "WePlanify est votre assistant de voyage intelligent qui vous aide à planifier vos voyages de groupe simplement et efficacement.",
-      },
-      {
-        question: "Comment fonctionne WePlanify ?",
-        answer: "Indiquez votre destination et vos préférences, notre IA crée un itinéraire personnalisé adapté à votre groupe en quelques secondes.",
+        answer: "WePlanify est un planificateur de voyage de groupe gratuit, accessible directement depuis le navigateur. Il combine un itinéraire collaboratif, des sondages de groupe, un budget partagé avec règlement automatique, des listes de bagages partagées et un assistant IA — tout en un, bilingue français/anglais.",
       },
       {
         question: "WePlanify est-il gratuit ?",
-        answer: "Nous proposons une version gratuite avec les fonctionnalités essentielles, ainsi que des plans premium pour des options avancées.",
+        answer: "Oui. La version gratuite couvre la grande majorité des voyages de groupe : itinéraires collaboratifs, sondages, budget partagé, listes de bagages et accès à l'assistant IA. Des plans premium existent pour augmenter les quotas (plus de voyages, plus d'appels IA). Aucune carte bancaire n'est requise pour s'inscrire.",
+      },
+      {
+        question: "Comment fonctionne WePlanify ?",
+        answer: "Créez un voyage en quelques secondes, invitez vos amis par email ou par lien, et démarrez la planification ensemble. Chacun peut éditer l'itinéraire, lancer un sondage, ajouter une dépense ou cocher un item de bagages. L'assistant IA peut générer un premier brouillon depuis une simple description de votre voyage.",
+      },
+      {
+        question: "Faut-il télécharger une application ?",
+        answer: "Non. WePlanify fonctionne directement dans le navigateur, sur mobile, tablette ou ordinateur. Aucune installation depuis l'App Store ou le Play Store n'est nécessaire.",
+      },
+      {
+        question: "Combien de personnes peuvent rejoindre un voyage ?",
+        answer: "WePlanify est conçu pour des groupes de 2 à 50+ participants. Il n'y a pas de limite stricte pour les groupes de taille normale.",
+      },
+      {
+        question: "Comment fonctionnent les sondages de groupe ?",
+        answer: "N'importe quel participant peut créer un sondage en quelques secondes : choix unique ou multiple, vote anonyme disponible (utile pour les choix sensibles au budget). Les résultats sont visibles en temps réel avec le détail par option. Les sondages peuvent être liés à des items de l'itinéraire (\"choisir le restaurant du Jour 2\").",
+      },
+      {
+        question: "Comment fonctionne le budget partagé ?",
+        answer: "Chaque participant peut enregistrer une dépense avec un payeur, un montant, une devise et une règle de partage (égal, parts personnalisées, ou exclure certaines personnes). WePlanify calcule en direct qui doit combien à qui, dans n'importe quelle devise avec conversion automatique. Les paiements anticipés (acomptes, réservations de groupe) sont gérés séparément des dépenses sur place.",
+      },
+      {
+        question: "Quelle est la différence entre WePlanify et Wanderlog ?",
+        answer: "Wanderlog est un excellent outil d'itinéraire mais n'a pas de sondages de groupe intégrés ni de système de règlement de budget partagé. WePlanify est pensé pour les groupes dès le départ, entièrement bilingue français/anglais, et inclut nativement les sondages et le budget partagé. Les deux sont gratuits au niveau d'entrée.",
+      },
+      {
+        question: "Quelle est la différence entre WePlanify et Splitwise ?",
+        answer: "Splitwise est excellent pour le partage de dépenses mais ce n'est pas un planificateur de voyage. WePlanify couvre l'ensemble du voyage (itinéraire, sondages, bagages, budget) et inclut un suivi de budget de type Splitwise pour les dépenses partagées du voyage.",
+      },
+      {
+        question: "Peut-on organiser un EVJF, EVG ou enterrement de vie de jeune fille/garçon avec WePlanify ?",
+        answer: "Oui, c'est l'un des cas d'usage les plus fréquents. Les sondages gèrent le \"qui choisit l'activité\", le budget partagé suit qui a payé quoi (y compris les acomptes), et les listes de bagages évitent les doublons. Le vote anonyme est utile quand les budgets varient au sein du groupe.",
+      },
+      {
+        question: "WePlanify fonctionne-t-il pour les voyageurs solo ?",
+        answer: "WePlanify peut être utilisé en solo, mais le produit est optimisé pour les groupes. Les voyageurs solo trouveront davantage de valeur dans TripIt (suivi de réservations) ou Stippl (carnet de voyage solo). WePlanify prend tout son sens dès qu'une deuxième personne rejoint le voyage.",
+      },
+      {
+        question: "Dans quelles langues WePlanify est-il disponible ?",
+        answer: "Anglais et français, intégralement traduits (URLs, contenu, emails, réponses de l'assistant IA). D'autres langues sont prévues à la roadmap.",
+      },
+      {
+        question: "Comment fonctionne l'assistant IA ?",
+        answer: "Décrivez votre voyage en langage naturel (\"4 amis, long week-end à Lisbonne, focus gastronomie, budget 500€ chacun\") et l'assistant propose des destinations, un itinéraire jour par jour, des activités et une estimation budgétaire. Il s'adapte aux sondages et au budget du groupe au fil du temps.",
       },
       {
         question: "Dans quels pays WePlanify est-il disponible ?",
         answer: "WePlanify fonctionne dans le monde entier et couvre des destinations dans plus de 190 pays.",
       },
       {
+        question: "WePlanify est-il conforme au RGPD ?",
+        answer: "Oui. WePlanify est conçu en Europe avec la conformité RGPD dès le premier jour. Les utilisateurs peuvent exporter et supprimer leurs données depuis les paramètres de leur compte.",
+      },
+      {
         question: "Comment contacter le support ?",
-        answer: "Vous pouvez nous joindre via notre page contact ou par email à support@weplanify.com.",
+        answer: "Vous pouvez nous joindre via notre page contact ou par email à contact@weplanify.com.",
       },
     ],
   },
@@ -42,23 +89,67 @@ const FAQ_BY_LOCALE: Record<"fr" | "en", FAQType> = {
     items: [
       {
         question: "What is WePlanify?",
-        answer: "WePlanify is your smart travel assistant that helps you plan group trips simply and efficiently.",
-      },
-      {
-        question: "How does WePlanify work?",
-        answer: "Tell us your destination and preferences, and our AI builds a personalized itinerary tailored to your group in seconds.",
+        answer: "WePlanify is a free, browser-based group trip planner. It combines a collaborative itinerary, group polls, a shared budget tracker with automatic settle-up, shared packing lists, and an AI assistant — all in one bilingual (English/French) tool.",
       },
       {
         question: "Is WePlanify free?",
-        answer: "We offer a free version with the essentials, plus premium plans for advanced features.",
+        answer: "Yes. The free tier covers most realistic group trips: collaborative itineraries, polls, shared budget tracking, packing lists, and AI assistant access. Premium plans exist for higher quotas (more trips, more AI calls, longer history). No credit card required to sign up.",
+      },
+      {
+        question: "How does WePlanify work?",
+        answer: "Create a trip in seconds, invite your friends by email or shareable link, and start planning together. Anyone can edit the itinerary, run a poll, add an expense, or check a packing item. The AI assistant can draft a first version from a simple description of your trip.",
+      },
+      {
+        question: "Do I need to download an app?",
+        answer: "No. WePlanify runs in any modern browser on mobile, tablet, or desktop. No App Store or Play Store download is required.",
+      },
+      {
+        question: "How many people can join a trip?",
+        answer: "WePlanify is designed for groups of 2 to 50+ participants. There is no hard limit for normal group sizes.",
+      },
+      {
+        question: "How do group polls work?",
+        answer: "Anyone in the trip can create a poll in seconds: single or multi-select, with an optional anonymous voting mode (useful for budget-sensitive choices). Results are visible in real time with per-option breakdowns. Polls can be linked to itinerary items (\"pick the restaurant for Day 2\").",
+      },
+      {
+        question: "How does the shared budget work?",
+        answer: "Each participant logs an expense with a payer, amount, currency, and split rule (equal, custom shares, or exclude specific people). WePlanify computes live who owes whom, in any currency with automatic conversion. Pre-paid items (deposits, group bookings) are tracked separately from on-trip spend.",
+      },
+      {
+        question: "How does WePlanify compare to Wanderlog?",
+        answer: "Wanderlog is a good itinerary tool but doesn't have built-in group polls or a settle-up-style shared budget tracker. WePlanify is group-first by design, fully bilingual English/French, and includes polls and shared budget natively. Both are free at the entry tier.",
+      },
+      {
+        question: "How does WePlanify compare to Splitwise?",
+        answer: "Splitwise is a great expense splitter but isn't a trip planner. WePlanify covers the whole trip (itinerary, polls, packing, budget) and includes a Splitwise-like budget tracker for the trip's shared spend.",
+      },
+      {
+        question: "Can I plan a bachelorette, bachelor, hen, or stag party with WePlanify?",
+        answer: "Yes — this is one of the most common use cases. Polls handle the \"who picks the activity\" decision, the shared budget tracks who paid for what (including pre-paid deposits), and the packing lists prevent duplicate gear. Anonymous voting is useful when budgets vary across the group.",
+      },
+      {
+        question: "Does WePlanify work for solo travellers?",
+        answer: "WePlanify can be used solo, but the product is optimized for groups. Solo travellers will get more value from TripIt (reservation tracking) or Stippl (solo travel journal). WePlanify shines once a second person joins the trip.",
+      },
+      {
+        question: "What languages does WePlanify support?",
+        answer: "English and French, fully translated end-to-end (URLs, content, emails, AI assistant responses). More languages are on the roadmap.",
+      },
+      {
+        question: "How does the AI assistant work?",
+        answer: "Describe the trip in plain language (\"4 friends, long weekend in Lisbon, foodie focus, budget 500€ each\") and the assistant proposes destinations, day-by-day itineraries, activities, and budget estimates. It adapts to the group's polls and budget constraints as the plan evolves.",
       },
       {
         question: "In which countries is WePlanify available?",
         answer: "WePlanify works worldwide and covers destinations in over 190 countries.",
       },
       {
+        question: "Is WePlanify GDPR-compliant?",
+        answer: "Yes. WePlanify is built in Europe with GDPR compliance from day one. Users can export and delete their data from account settings.",
+      },
+      {
         question: "How can I contact support?",
-        answer: "You can reach us via our contact page or by email at support@weplanify.com.",
+        answer: "You can reach us via our contact page or by email at contact@weplanify.com.",
       },
     ],
   },

--- a/src/app/structured-data.tsx
+++ b/src/app/structured-data.tsx
@@ -3,31 +3,51 @@ export default function StructuredData() {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "WePlanify",
-    "description": "WePlanify is a free collaborative group trip planner. Plan itineraries together, vote with group polls, track shared budgets, and organize every detail of your group travel in one app.",
+    "alternateName": ["WePlanify Group Trip Planner", "WePlanify — Voyages de Groupe"],
+    "description": "WePlanify is a free collaborative group trip planner. Plan itineraries together, vote with group polls, track shared budgets, and organize every detail of your group travel in one bilingual (English/French) browser app.",
     "url": "https://www.weplanify.com",
     "applicationCategory": "TravelApplication",
-    "operatingSystem": "Web",
+    "applicationSubCategory": "GroupTripPlanner",
+    "operatingSystem": "Web (any modern browser)",
+    "inLanguage": ["en", "fr"],
     "offers": {
       "@type": "Offer",
       "price": "0",
-      "priceCurrency": "USD"
+      "priceCurrency": "USD",
+      "availability": "https://schema.org/InStock",
+      "category": "Free with optional premium tier"
     },
     "author": {
       "@type": "Organization",
       "name": "WePlanify",
       "url": "https://weplanify.com"
     },
+    "publisher": {
+      "@type": "Organization",
+      "name": "WePlanify",
+      "url": "https://weplanify.com"
+    },
+    "audience": {
+      "@type": "Audience",
+      "audienceType": "Groups of friends, families, and teams planning trips together"
+    },
     "featureList": [
-      "Collaborative group trip planning",
-      "Day-by-day itinerary builder",
-      "Group polls and voting system",
-      "Shared budget tracker",
-      "Activity and restaurant discovery",
-      "Shared packing lists",
-      "Real-time group collaboration"
+      "Collaborative day-by-day itinerary builder",
+      "Group polls with anonymous voting",
+      "Shared budget tracker with split-aware settle-up",
+      "Shared packing lists with per-traveller assignments",
+      "AI assistant that drafts trips from natural-language prompts",
+      "Activity, restaurant, and tour discovery per destination",
+      "3D globe view of past and planned trips",
+      "Real-time multi-user collaboration",
+      "Fully bilingual English and French",
+      "No app download required — works in any browser"
     ],
     "screenshot": "https://www.weplanify.com/app-screenshot.png",
-    "softwareVersion": "1.0.0"
+    "softwareVersion": "1.0.0",
+    "datePublished": "2026-05-08",
+    "browserRequirements": "Requires JavaScript; runs in any modern browser",
+    "isAccessibleForFree": true
   };
 
   return (


### PR DESCRIPTION
LLMs (ChatGPT, Perplexity, Claude, Gemini) increasingly cite sites with high-quality machine-readable surfaces. Prod data showed ChatGPT.com is already a steady referral source — this pass expands the surface area we expose so those citations carry more weight.

- public/llms.txt: expanded with quick facts, comparison snapshot, use cases, pricing — covering common LLM extraction prompts.
- public/llms-full.txt (new): long-form reference with feature deep-dive, per-competitor comparisons, and a 16-question FAQ written the way users search and LLMs quote.
- src/app/structured-data.tsx: enriched SoftwareApplication schema with inLanguage, applicationSubCategory, audience, isAccessibleForFree, datePublished, and a fuller featureList.
- src/app/[locale]/faq/page.tsx: FAQ fallback bumped from 5 to 16 questions per locale, ordered by intent frequency, including direct competitor comparisons (Wanderlog, Splitwise, TripIt, Stippl) and high-intent use cases (bachelorette/EVJF). The FAQPage JSON-LD picks them up automatically.