### PR TITLE
fix(brand): use canonical "WePlanify" casing in user-visible strings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -37,7 +37,7 @@
     "cookiePolicy": "Cookie Policy"
   },
   "metadata": {
-    "title": "Weplanify - Plan your perfect trip",
-    "description": "Weplanify helps you plan your perfect trip with AI-powered recommendations and personalized itineraries."
+    "title": "WePlanify - Plan your perfect trip",
+    "description": "WePlanify helps you plan your perfect trip with AI-powered recommendations and personalized itineraries."
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -37,7 +37,7 @@
     "cookiePolicy": "Politique des cookies"
   },
   "metadata": {
-    "title": "Weplanify - Planifiez votre voyage parfait",
-    "description": "Weplanify vous aide a planifier votre voyage parfait avec des recommandations basees sur l'IA et des itineraires personnalises."
+    "title": "WePlanify - Planifiez votre voyage parfait",
+    "description": "WePlanify vous aide a planifier votre voyage parfait avec des recommandations basees sur l'IA et des itineraires personnalises."
   }
 }

--- a/src/app/[locale]/features/[slug]/features/PlanningFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/PlanningFeature.tsx
@@ -32,7 +32,7 @@ const COPY: Record<Lang, {
 }> = {
   fr: {
     you: "Toi",
-    brand: "Weplanify IA",
+    brand: "WePlanify IA",
     chatBubbles: [
       "Je veux passer 2 semaines au Japon en avril avec ma copine. On adore la nature, la cuisine et les temples. Budget moyen.",
       "Excellent choix ! Le Japon en avril, c'est la saison des cerisiers. Je suggère un itinéraire Tokyo — Kyoto — Osaka avec des étapes à Nara et Hakone. Tu veux voir les options d'hébergement ?",
@@ -65,7 +65,7 @@ const COPY: Record<Lang, {
   },
   en: {
     you: "You",
-    brand: "Weplanify AI",
+    brand: "WePlanify AI",
     chatBubbles: [
       "I want to spend 2 weeks in Japan in April with my girlfriend. We love nature, food, and temples. Medium budget.",
       "Great choice! Japan in April is cherry blossom season. I suggest a Tokyo — Kyoto — Osaka route with stops in Nara and Hakone. Want me to show you accommodation options?",

--- a/src/components/FeatureJsonLd.tsx
+++ b/src/components/FeatureJsonLd.tsx
@@ -39,12 +39,12 @@ export default function FeatureJsonLd({
     "url": featureUrl,
     "isPartOf": {
       "@type": "WebSite",
-      "name": "Weplanify",
+      "name": "WePlanify",
       "url": "https://weplanify.com"
     },
     "about": {
       "@type": "SoftwareApplication",
-      "name": "Weplanify",
+      "name": "WePlanify",
       "applicationCategory": "TravelApplication",
       "operatingSystem": "Web, iOS, Android",
       "offers": {


### PR DESCRIPTION
## Summary
- Standardise la casse de la marque sur **WePlanify** (au lieu de `Weplanify`) dans les chaînes visibles côté utilisateur / moteurs de recherche.
- Fix `<title>` et meta description (FR + EN), le label `brand` du mockup chat dans `PlanningFeature`, et les noms `WebSite` / `SoftwareApplication` dans le JSON-LD.
- Pas touché aux identifiants camelCase d'i18n (`chooseWeplanifyTitle`, `whoWeplanify`, etc.) — ce sont des clés JS, pas du texte rendu.

## Test plan
- [ ] Vérifier `<title>` et `<meta description>` sur `/en` et `/fr`
- [ ] Vérifier le label "WePlanify IA / AI" dans le mockup de chat sur les pages `features/[slug]` qui utilisent `PlanningFeature`
- [ ] Inspecter le JSON-LD (`FeatureJsonLd`) pour confirmer `"name": "WePlanify"` côté `WebSite` et `SoftwareApplication`

🤖 Generated with [Claude Code](https://claude.com/claude-code)