### PR TITLE
fix(meta): remove duplicate "WePlanify" in page titles

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -22,12 +22,12 @@ export function generateStaticParams() {
 
 const aboutMeta = {
   en: {
-    title: "About WePlanify — The Free Group Trip Planner for Friends",
+    title: "About Us — The Free Group Trip Planner for Friends",
     description:
       "WePlanify is the free, collaborative trip planner for friends, families and teams. Discover the story, the mission and the team behind real-time group travel planning.",
   },
   fr: {
-    title: "À Propos de WePlanify — Le Planificateur de Voyage de Groupe",
+    title: "À Propos — Le Planificateur de Voyage de Groupe",
     description:
       "WePlanify est le planificateur de voyage de groupe gratuit et collaboratif pour amis, familles et équipes. Découvrez l'histoire, la mission et l'équipe derrière l'app.",
   },

--- a/src/app/[locale]/bachelorette-trip/page.tsx
+++ b/src/app/[locale]/bachelorette-trip/page.tsx
@@ -28,7 +28,7 @@ export function generateStaticParams() {
 const content = {
   en: {
     meta: {
-      title: "Plan a Bachelorette Trip — Organize the Perfect Party | WePlanify",
+      title: "Plan a Bachelorette Trip — Organize the Perfect Party",
       description:
         "Plan the ultimate bachelorette trip with WePlanify. Coordinate schedules, vote on activities, manage a shared budget, and build a day-by-day itinerary — all in one free bachelorette weekend organizer.",
     },
@@ -244,8 +244,7 @@ const content = {
   },
   fr: {
     meta: {
-      title:
-        "Organiser un EVJF — Planifiez l'Enterrement de Vie de Jeune Fille Parfait | WePlanify",
+      title: "Organiser un EVJF — Planifie l'Enterrement de Vie de Jeune Fille Parfait",
       description:
         "Organisez l'EVJF parfait avec WePlanify. Coordonnez les emplois du temps, votez pour les activités, gérez une cagnotte commune et créez un programme jour par jour — le tout dans une application EVJF gratuite.",
     },

--- a/src/app/[locale]/birthday-trip/page.tsx
+++ b/src/app/[locale]/birthday-trip/page.tsx
@@ -28,7 +28,7 @@ export function generateStaticParams() {
 const content = {
   en: {
     meta: {
-      title: "Birthday Trip Planner — Plan the Ultimate Birthday Getaway | WePlanify",
+      title: "Birthday Trip Planner — Plan the Ultimate Birthday Getaway",
       description:
         "Plan your birthday trip with WePlanify, the free birthday trip planner. Coordinate dates with your friends, vote on the destination, split the budget, and build a day-by-day itinerary — perfect for 30th, 40th, 50th milestones or any birthday getaway.",
     },
@@ -244,7 +244,7 @@ const content = {
   },
   fr: {
     meta: {
-      title: "Voyage Anniversaire — Organisez un Anniversaire Inoubliable | WePlanify",
+      title: "Voyage Anniversaire — Organise un Anniversaire Inoubliable",
       description:
         "Organise ton voyage anniversaire avec WePlanify, l'application gratuite pour planifier un week-end anniversaire entre amis. Coordonne les dates, vote pour la destination, gère la cagnotte commune et crée un programme jour par jour — idéal pour les 30, 40, 50 ans ou n'importe quel anniversaire à fêter ailleurs.",
     },

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -15,12 +15,12 @@ const SITE_URL = "https://www.weplanify.com";
 
 const contactMeta = {
   en: {
-    title: "Contact WePlanify — Get in Touch With Our Team",
+    title: "Contact Us — Get in Touch With Our Team",
     description:
       "Have a question about WePlanify? Need help planning your group trip? Reach out to our team — we typically respond within 24 hours.",
   },
   fr: {
-    title: "Contactez WePlanify — Notre Équipe Vous Répond Sous 24h",
+    title: "Nous Contacter — Notre Équipe Te Répond Sous 24h",
     description:
       "Une question sur WePlanify ? Besoin d'aide pour organiser votre voyage de groupe ? Contactez notre équipe — nous répondons généralement sous 24 heures.",
   },

--- a/src/app/[locale]/events/page.tsx
+++ b/src/app/[locale]/events/page.tsx
@@ -103,7 +103,7 @@ const events: EventEntry[] = [
 const content = {
   en: {
     meta: {
-      title: "2026 Event Trip Planners — Free, for Groups | WePlanify",
+      title: "2026 Event Trip Planners — Free, for Groups",
       description:
         "Plan your 2026 event trip with WePlanify. Dedicated free planners for the FIFA World Cup, Champions League Final, Tomorrowland, Hellfest, Ultra Europe and the total solar eclipse — built for groups of fans who travel together.",
     },
@@ -129,7 +129,7 @@ const content = {
   },
   fr: {
     meta: {
-      title: "Planificateurs Voyage Événement 2026 — Gratuit, pour les Groupes | WePlanify",
+      title: "Planificateurs Voyage Événement 2026 — Gratuit, pour les Groupes",
       description:
         "Planifie ton voyage événement 2026 avec WePlanify. Planificateurs gratuits dédiés pour la Coupe du Monde FIFA, la finale Ligue des Champions, Tomorrowland, Hellfest, Ultra Europe et l'éclipse solaire totale — conçus pour les groupes de fans qui voyagent ensemble.",
     },

--- a/src/app/[locale]/partnership/page.tsx
+++ b/src/app/[locale]/partnership/page.tsx
@@ -15,7 +15,7 @@ const SITE_URL = "https://www.weplanify.com";
 
 const partnershipMeta = {
   en: {
-    title: "Partner with WePlanify — Partnership Opportunities",
+    title: "Become a Partner — Partnership Opportunities",
     description:
       "Work with WePlanify. Whether you're a travel provider, media partner, creator, or building an integration — tell us about your project and our team will get back to you.",
     h1: "Let's build something together",
@@ -23,7 +23,7 @@ const partnershipMeta = {
       "Tell us about your project. Affiliates, media, travel providers, creators, integrations — we're open.",
   },
   fr: {
-    title: "Partenariat WePlanify — Devenir Partenaire",
+    title: "Devenir Partenaire — Programme de Partenariat",
     description:
       "Travaillez avec WePlanify. Que vous soyez un acteur du voyage, un média, un créateur ou que vous souhaitiez intégrer notre produit — parlez-nous de votre projet.",
     h1: "Construisons quelque chose ensemble",


### PR DESCRIPTION
Browser tabs were rendering "Foo | WePlanify | WePlanify" on several landings because page-level meta.title strings already contained "| WePlanify" while the metadata template (`%s | WePlanify` from generateMetadataFromSanity) appended it again.

Two patterns of duplication, both fixed:

1. Explicit "| WePlanify" suffix in the page-level title (6 pages): birthday-trip, bachelorette-trip, events (each en + fr). Removed the suffix — the title template now adds it exactly once.

2. "WePlanify" baked into the natural phrase (6 pages): about, contact, partnership (each en + fr). Reworded to drop the brand from the inline phrase:
   - "Contact WePlanify — …" → "Contact Us — …"
   - "About WePlanify — …" → "About Us — …"
   - "À Propos de WePlanify — …" → "À Propos — …"
   - "Partner with WePlanify — …" → "Become a Partner — …"
   - "Partenariat WePlanify — …" → "Devenir Partenaire — Programme de Partenariat"
   - "Contactez WePlanify — Notre Équipe Vous Répond…" → "Nous Contacter — Notre Équipe Te Répond…" (also flips vous → tu for consistency with the rest of the FR brand voice)

Verified by fetching all 12 routes and confirming each renders "<title>… | WePlanify</title>" with exactly one brand mention.

Note: openGraph.title still mirrors meta.title (without the template suffix), which is fine — the OG siteName field already conveys the brand in social previews.