### PR TITLE
fix(WP-315): enlarge the tiny stat labels under the big numbers

### DIFF
--- a/src/components/StackingCards.tsx
+++ b/src/components/StackingCards.tsx
@@ -173,7 +173,7 @@ function Card({ card, index, locale }: { card: CardData; index: number; locale: 
                 <p className="text-[#001E13] text-4xl lg:text-5xl xl:text-6xl font-londrina-solid mb-2">
                   {stat.value}
                 </p>
-                <p className="text-[#001E13] text-xs lg:text-sm font-nanum-pen">
+                <p className="text-[#001E13] text-base lg:text-lg font-nanum-pen">
                   {stat.label}
                 </p>
               </div>

--- a/src/components/StatsBlock.tsx
+++ b/src/components/StatsBlock.tsx
@@ -58,7 +58,7 @@ export default function StatsBlock({ locale = "en" }: StatsBlockProps) {
                 </svg>
               )}
             </div>
-            <p className="text-[#001E13] text-xs lg:text-sm font-nanum-pen">
+            <p className="text-[#001E13] text-base lg:text-lg font-nanum-pen">
               {stat.label}
             </p>
           </div>


### PR DESCRIPTION
Closes WP-315 — https://weplanify.youtrack.cloud/issue/WP-315

## Problème (signalé par Théo)
Sur la landing, les petits libellés sous les gros chiffres des sections stats étaient illisibles : « countries covered », « Traveler satisfaction » (carte jaune) et « Partners » (carte turquoise). Ils étaient en `text-xs lg:text-sm` avec la police manuscrite `font-nanum-pen`, qui rend visuellement fin/petit.

## Fix
`text-xs lg:text-sm` → `text-base lg:text-lg` sur le libellé de stat, aux deux endroits :
- `src/components/StatsBlock.tsx` (carte « Trusted by groups who travel smarter »)
- `src/components/StackingCards.tsx` (cartes empilées, ex. « 10+ Partners »)

Le libellé reste sous la taille du gros chiffre (`text-4xl→6xl`) et ≈ celle du titre, donc la hiérarchie visuelle est préservée.

## Vérification
Changement de classe Tailwind uniquement (taille de police). À confirmer sur le **preview deploy** de la PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)