### PR TITLE
fix(WP-316): shrink the scrolling tagline banner

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -187,7 +187,7 @@ export default async function HomePage({ params }: Props) {
       {/* Scrolling Banner Section */}
       {banner?.items && banner.items.length > 0 && (
         <div
-          className="py-4 lg:py-6 overflow-hidden"
+          className="py-2 lg:py-3 overflow-hidden"
           style={{
             backgroundColor: banner.backgroundColor || "#61DBD5",
             color: banner.textColor || "#001E13",
@@ -197,10 +197,10 @@ export default async function HomePage({ params }: Props) {
             <div className="flex items-center gap-8 lg:gap-12">
               {banner.items.map((item, index) => (
                 <>
-                  <span key={`item-${index}`} className="text-xl lg:text-3xl font-londrina-solid">
+                  <span key={`item-${index}`} className="text-base lg:text-xl font-londrina-solid">
                     {item}
                   </span>
-                  <span key={`dot-${index}`} className="text-xl lg:text-3xl">
+                  <span key={`dot-${index}`} className="text-base lg:text-xl">
                     •
                   </span>
                 </>
@@ -209,10 +209,10 @@ export default async function HomePage({ params }: Props) {
             <div className="flex items-center gap-8 lg:gap-12 ml-8 lg:ml-12">
               {banner.items.map((item, index) => (
                 <>
-                  <span key={`item2-${index}`} className="text-xl lg:text-3xl font-londrina-solid">
+                  <span key={`item2-${index}`} className="text-base lg:text-xl font-londrina-solid">
                     {item}
                   </span>
-                  <span key={`dot2-${index}`} className="text-xl lg:text-3xl">
+                  <span key={`dot2-${index}`} className="text-base lg:text-xl">
                     •
                   </span>
                 </>


### PR DESCRIPTION
Closes WP-316 — https://weplanify.youtrack.cloud/issue/WP-316

## Demande (Théo)
« masquer ce bando ou le rétrécir en fonction du rendu ». Le titre délègue le choix hide/shrink.

## Choix : rétrécir (option la moins destructive)
La bande teal défilante (« GROUP TRIPS, SIMPLIFIED · … ») était haute (`py-4 lg:py-6`, texte `text-xl lg:text-3xl`) et collait la section sombre du dessus. Réduite à `py-2 lg:py-3` + texte `text-base lg:text-xl` → ticker discret.

## À noter (séparé)
Le vrai défaut visuel restant = les **photos de villes de la section sombre au-dessus se font trancher** à la frontière avec la bande (la section chevauche le banner de ~20px). Pas corrigé ici (touche la mise en page de la section destinations) — à voir si on veut le traiter dans un ticket dédié.

## Vérif
Changement de classes Tailwind uniquement. À valider sur le preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)