### PR TITLE
fix(WP-318): hero orange bubble missing background + FR copy reword

### DIFF
--- a/src/components/HeroPitchWall.tsx
+++ b/src/components/HeroPitchWall.tsx
@@ -111,7 +111,7 @@ const BUBBLES: Record<Lang, Bubble[]> = {
   fr: [
     { text: 'Un truc chaud en mars avec 4 potes', color: 'lime', x: 6, y: 18, rotate: -4, delay: 0 },
     { text: 'Honeymoon sans les touristes', color: 'cream', x: 78, y: 14, rotate: 3, delay: 0.6 },
-    { text: 'Japon en famille, pas crevé', color: 'orange', x: 82, y: 58, rotate: -2, delay: 1.2, desktopOnly: true },
+    { text: 'Japon en famille, sans s\'épuiser', color: 'orange', x: 82, y: 58, rotate: -2, delay: 1.2, desktopOnly: true },
     { text: 'EVJF à Lisbonne, 3 jours max', color: 'white', x: 4, y: 62, rotate: 2, delay: 0.3, desktopOnly: true },
     { text: 'Road trip voir les aurores', color: 'lime', x: 70, y: 80, rotate: -3, delay: 1.6, desktopOnly: true },
     { text: 'Dépaysement en novembre, pas loin', color: 'cream', x: 10, y: 84, rotate: 4, delay: 0.9, desktopOnly: true },
@@ -121,7 +121,7 @@ const BUBBLES: Record<Lang, Bubble[]> = {
 const BUBBLE_CLASSES: Record<Bubble['color'], string> = {
   lime: 'bg-[#EEF899] text-[#001E13]',
   cream: 'bg-[#FFFBF5] text-[#001E13]',
-  orange: 'bg-orange/90 text-white',
+  orange: 'bg-orange text-white',
   white: 'bg-white/95 text-[#001E13]',
 };
 


### PR DESCRIPTION
Closes WP-318 — remontée Théo (WhatsApp)

## Problèmes (bulle hero pointée par la flèche rouge)
1. **Pas de fond** : la bulle « Japon en famille, pas crevé » (`color: 'orange'`) s'affichait sans fond.
2. **Trad** : « pas crevé » sonne mal.

## Cause racine (no background)
`BUBBLE_CLASSES.orange` valait `bg-orange/90`. Or `orange` n'est **pas** un token de couleur Tailwind — `.bg-orange` / `.text-orange` sont des classes CSS écrites à la main dans `globals.css` (`.bg-orange { background-color:#D42D10 }`). Le modificateur d'opacité `/90` ne s'applique qu'aux vrais tokens Tailwind → `bg-orange/90` = utilitaire invalide → **aucun fond généré** (confirmé via le DOM prod : `background-color: rgba(0,0,0,0)`).

## Fix
- `bg-orange/90` → `bg-orange` (fond solide #D42D10). Cohérent avec les autres bulles (fond solide).
- FR : « Japon en famille, pas crevé » → « Japon en famille, sans s'épuiser » (fidèle à l'EN « not exhausting »). EN inchangé.

## À noter (hors scope)
Même bug `bg-orange/90` présent sur des **hovers de boutons** (lignes ~336, ~862 : `hover:bg-orange/90`) → le fond disparaît au survol. Pas touché ici pour rester focus sur le ticket (et ton composant est en cours de rework). À traiter à part si tu veux.

## Base & coordination
Branche basée sur `main` (qui contient ces bulles). ⚠️ Ta WIP `feat/hero-pitch-gating-medium` retravaille `HeroPitchWall` et a retiré ces bulles localement → à réconcilier au merge, comme convenu.

## Vérif
Classes Tailwind + une string. À valider sur le preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)