### PR TITLE
fix(WP-323): move social links to CTA column

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -53,6 +53,33 @@ function SocialIcon({ platform }: { platform: string }) {
   );
 }
 
+// Reusable social media links (Instagram, TikTok). Moved up into the CTA column
+// for better visibility / conversion (WP-323), while still kept in the footer bottom bar.
+function SocialLinks({ className = "" }: { className?: string }) {
+  return (
+    <div className={`flex items-center gap-4 ${className}`}>
+      <a
+        href="https://www.instagram.com/weplanify"
+        className="text-[#001E13] hover:text-[#F6391A] transition-colors"
+        aria-label="Instagram"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <SocialIcon platform="instagram" />
+      </a>
+      <a
+        href="https://www.tiktok.com/@weplanify"
+        className="text-[#001E13] hover:text-[#F6391A] transition-colors"
+        aria-label="TikTok"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <SocialIcon platform="tiktok" />
+      </a>
+    </div>
+  );
+}
+
 interface FooterProps {
   footerData?: FooterType | null;
 }
@@ -258,6 +285,13 @@ export default function Footer({ footerData }: FooterProps) {
                   </button>
                 </Link>
               )}
+              {/* Social links surfaced in the CTA column for visibility (WP-323) */}
+              <div className="mt-8">
+                <p className="text-[#001E13] text-sm font-karla font-bold mb-3">
+                  {locale === "fr" ? "Suivez-nous" : "Follow us"}
+                </p>
+                <SocialLinks />
+              </div>
             </div>
           ) : (
             /* Default Newsletter Section when no CTA is configured */
@@ -292,20 +326,21 @@ export default function Footer({ footerData }: FooterProps) {
                   </button>
                 </form>
               )}
+              {/* Social links surfaced in the CTA column for visibility (WP-323) */}
+              <div className="mt-8">
+                <p className="text-[#001E13] text-sm font-karla font-bold mb-3">
+                  {locale === "fr" ? "Suivez-nous" : "Follow us"}
+                </p>
+                <SocialLinks />
+              </div>
             </div>
           )}
         </div>
 
         {/* Footer Bottom */}
         <div className="flex flex-col md:flex-row justify-between items-center gap-6 pt-8 lg:pt-10 border-t border-[#001E13]/10">
-          {/* Social Links + Product Hunt */}
+          {/* Product Hunt badge (social icons moved up to the CTA column — WP-323) */}
           <div className="flex flex-wrap gap-4 items-center order-2 md:order-1">
-            <a href="https://www.instagram.com/weplanify" className="text-[#001E13] hover:text-[#F6391A] transition-colors" aria-label="Instagram" target="_blank" rel="noopener noreferrer">
-              <SocialIcon platform="instagram" />
-            </a>
-            <a href="https://www.tiktok.com/@weplanify" className="text-[#001E13] hover:text-[#F6391A] transition-colors" aria-label="TikTok" target="_blank" rel="noopener noreferrer">
-              <SocialIcon platform="tiktok" />
-            </a>
             <a
               href="https://www.producthunt.com/products/weplanify?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-weplanify"
               target="_blank"


### PR DESCRIPTION
## WP-323 — move social media links to a more prominent location

Per Théo's screenshot on the ticket: arrows point **from** the Instagram/TikTok icons in the footer bottom bar **to** the empty space inside the "Join the adventure!" CTA column. Goal: surface socials higher up to boost conversion.

### What changed
- Extracted a reusable `SocialLinks` component (Instagram + TikTok) from the inline markup.
- **Moved** the social icons out of the footer bottom bar **into the CTA column**, below the action, under a "Follow us" / "Suivez-nous" label.
- Added the block to **both** the configured-CTA branch ("Join the adventure!") and the default-newsletter fallback branch, so the socials are always present in that column regardless of Sanity config.
- The **Product Hunt badge stays** in the bottom bar (it was not part of what Théo circled).

### i18n
New label is localized: `Follow us` (en) / `Suivez-nous` (fr).

### Files
- `src/components/Footer.tsx`

### Notes
- Moved (not duplicated) the icons — the bottom bar no longer renders them, matching the "move" intent of the ticket.
- Could not run `next build`/`tsc` in the isolated worktree (deps not installed; main working tree has a teammate's WIP and must not be touched). JSX structure was reviewed manually and is balanced. Recommend a visual check on the Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
