### PR TITLE
fix(WP-320): harmonize section spacings on the homepage

### DIFF
--- a/src/components/CTABanner.tsx
+++ b/src/components/CTABanner.tsx
@@ -45,7 +45,7 @@ export default function CTABanner({ locale = "en" }: CTABannerProps) {
   const content = CONTENT[lang];
 
   return (
-    <div className="px-4 lg:px-8 pt-8 lg:pt-12">
+    <div className="px-4 lg:px-8 pb-2 lg:pb-3">
       <div className="max-w-[1536px] mx-auto">
         <section className="relative overflow-hidden rounded-[24px] lg:rounded-[40px] min-h-[600px] lg:min-h-[700px]">
           <div className="absolute inset-0 z-0">

--- a/src/components/CTABanner.tsx
+++ b/src/components/CTABanner.tsx
@@ -45,7 +45,7 @@ export default function CTABanner({ locale = "en" }: CTABannerProps) {
   const content = CONTENT[lang];
 
   return (
-    <div className="px-4 lg:px-8 pb-2 lg:pb-3">
+    <div className="px-4 lg:px-8 pt-8 lg:pt-12">
       <div className="max-w-[1536px] mx-auto">
         <section className="relative overflow-hidden rounded-[24px] lg:rounded-[40px] min-h-[600px] lg:min-h-[700px]">
           <div className="absolute inset-0 z-0">

--- a/src/components/FAQSupport.tsx
+++ b/src/components/FAQSupport.tsx
@@ -143,7 +143,7 @@ export default function FAQSupport({ locale = "en" }: FAQSupportProps) {
   };
 
   return (
-    <div className="px-4 lg:px-8 pb-4 lg:pb-6 pt-2 lg:pt-3">
+    <div className="px-4 lg:px-8 pt-8 lg:pt-12 pb-4 lg:pb-6">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}

--- a/src/components/StackingCards.tsx
+++ b/src/components/StackingCards.tsx
@@ -240,7 +240,7 @@ export default function StackingCards({ locale = "en" }: StackingCardsProps) {
 
   return (
     <div ref={containerRef} className="bg-[#FFFBF5]">
-      <div className="max-w-[1536px] mx-auto px-4 lg:px-8 pt-12 lg:pt-20 pb-6 lg:pb-10">
+      <div className="max-w-[1536px] mx-auto px-4 lg:px-8 pt-8 lg:pt-12 pb-6 lg:pb-10">
         <h2 className="text-[#001E13] text-4xl lg:text-5xl xl:text-6xl font-londrina-solid text-center">
           {title}
         </h2>


### PR DESCRIPTION
Closes WP-320 — remontée Théo

## Problème
Espacements verticaux inégaux entre les sections sous la ligne de flottaison de la home (avant « A group travel planner… » et entre la bande défilante et « Everything You Need to Plan a Group Trip »). Chaque section avait sa propre valeur de padding → gaps incohérents.

## Fix (3 fichiers, classes Tailwind uniquement, lg: préservés)
Normalisation du padding-top de chaque section sur le rythme maison existant `pt-8 lg:pt-12` (déjà utilisé par FeatureImageSection, miroir du `pb-8 lg:pb-12` de la section témoignages) :
- `StackingCards.tsx` : header `pt-12 lg:pt-20` → `pt-8 lg:pt-12`
- `CTABanner.tsx` : `pb-2 lg:pb-3` (bottom) → `pt-8 lg:pt-12` (top)
- `FAQSupport.tsx` : `pt-2 lg:pt-3` → `pt-8 lg:pt-12`

Un seul "propriétaire" du padding par haut de section (comme le design d'origine) pour éviter les gaps qui doublent.

## Note review
- `StackingCards` garde son `pb-6 lg:pb-10` (gap interne header→cards, pas un seam de section).
- Pas de build local (worktree sans node_modules) → classes-only, à confirmer sur le **preview Vercel** (seams banner→cards, cards→feature, feature→CTA, CTA→FAQ, en + fr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)