### PR TITLE
fix(seo): canonical locale-aware URLs in feature pages structured data

### DIFF
--- a/src/app/[locale]/features/[slug]/features/BudgetFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/BudgetFeature.tsx
@@ -382,7 +382,8 @@ export default function BudgetFeature({ data }: { data: FeaturePageData }) {
       <FeatureJsonLd
         featureName={data.seoTitle}
         featureDescription={data.seoDescription}
-        featureUrl={`https://weplanify.com/features/${data.slug}`}
+        locale={locale}
+        slug={data.slug}
         faqItems={data.faqItems}
       />
 

--- a/src/app/[locale]/features/[slug]/features/CollaborationFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/CollaborationFeature.tsx
@@ -187,7 +187,8 @@ export default function CollaborationFeature({ data }: { data: FeaturePageData }
       <FeatureJsonLd
         featureName={data.seoTitle}
         featureDescription={data.seoDescription}
-        featureUrl={`https://weplanify.com/features/${data.slug}`}
+        locale={locale}
+        slug={data.slug}
         faqItems={data.faqItems}
       />
 

--- a/src/app/[locale]/features/[slug]/features/ExploreFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/ExploreFeature.tsx
@@ -249,7 +249,8 @@ export default function ExploreFeature({ data }: { data: FeaturePageData }) {
       <FeatureJsonLd
         featureName={data.seoTitle}
         featureDescription={data.seoDescription}
-        featureUrl={`https://weplanify.com/features/${data.slug}`}
+        locale={locale}
+        slug={data.slug}
         faqItems={data.faqItems}
       />
 

--- a/src/app/[locale]/features/[slug]/features/ItineraryFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/ItineraryFeature.tsx
@@ -104,7 +104,8 @@ export default function ItineraryFeature({ data }: { data: FeaturePageData }) {
       <FeatureJsonLd
         featureName={data.seoTitle}
         featureDescription={data.seoDescription}
-        featureUrl={`https://weplanify.com/features/${data.slug}`}
+        locale={locale}
+        slug={data.slug}
         faqItems={data.faqItems}
       />
 

--- a/src/app/[locale]/features/[slug]/features/MemoriesFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/MemoriesFeature.tsx
@@ -361,7 +361,8 @@ export default function MemoriesFeature({ data }: { data: FeaturePageData }) {
       <FeatureJsonLd
         featureName={data.seoTitle || (locale === 'en' ? "Memories - Travel Photo Album" : "Souvenirs - Album Photo de Voyage")}
         featureDescription={data.seoDescription || t.heroDescription}
-        featureUrl="https://weplanify.com/features/memories"
+        locale={locale}
+        slug="memories"
         faqItems={t.faq}
       />
 

--- a/src/app/[locale]/features/[slug]/features/PackingFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/PackingFeature.tsx
@@ -255,7 +255,8 @@ export default function PackingFeature({ data }: { data: FeaturePageData }) {
       <FeatureJsonLd
         featureName={data.seoTitle}
         featureDescription={data.seoDescription}
-        featureUrl={`https://weplanify.com/features/${data.slug}`}
+        locale={locale}
+        slug={data.slug}
         faqItems={data.faqItems}
       />
 

--- a/src/app/[locale]/features/[slug]/features/PlanningFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/PlanningFeature.tsx
@@ -223,7 +223,8 @@ export default function PlanningFeature({ data }: { data: FeaturePageData }) {
       <FeatureJsonLd
         featureName={data.seoTitle}
         featureDescription={data.seoDescription}
-        featureUrl={`https://weplanify.com/features/${data.slug}`}
+        locale={locale}
+        slug={data.slug}
         faqItems={data.faqItems}
       />
 

--- a/src/app/[locale]/features/[slug]/features/PollsFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/PollsFeature.tsx
@@ -239,7 +239,8 @@ export default function PollsFeature({ data }: { data: FeaturePageData }) {
       <FeatureJsonLd
         featureName={data.seoTitle}
         featureDescription={data.seoDescription}
-        featureUrl={`https://weplanify.com/features/${data.slug}`}
+        locale={locale}
+        slug={data.slug}
         faqItems={data.faqItems}
       />
 

--- a/src/app/[locale]/features/[slug]/features/TransportFeature.tsx
+++ b/src/app/[locale]/features/[slug]/features/TransportFeature.tsx
@@ -204,7 +204,8 @@ export default function TransportFeature({ data }: { data: FeaturePageData }) {
       <FeatureJsonLd
         featureName={data.seoTitle}
         featureDescription={data.seoDescription}
-        featureUrl={`https://weplanify.com/features/${data.slug}`}
+        locale={locale}
+        slug={data.slug}
         faqItems={data.faqItems}
       />
 

--- a/src/components/FeatureJsonLd.tsx
+++ b/src/components/FeatureJsonLd.tsx
@@ -6,16 +6,24 @@ interface FAQItem {
 interface FeatureJsonLdProps {
   featureName: string;
   featureDescription: string;
-  featureUrl: string;
+  locale: string;
+  slug: string;
   faqItems: FAQItem[];
 }
+
+const SITE_URL = "https://www.weplanify.com";
 
 export default function FeatureJsonLd({
   featureName,
   featureDescription,
-  featureUrl,
+  locale,
+  slug,
   faqItems,
 }: FeatureJsonLdProps) {
+  // Canonical, locale-aware URL — must match the page canonical for valid structured data
+  const featureUrl = `${SITE_URL}/${locale}/features/${slug}`;
+  const homeLabel = locale === "fr" ? "Accueil" : "Home";
+
   // FAQPage Schema
   const faqSchema = {
     "@context": "https://schema.org",
@@ -40,7 +48,7 @@ export default function FeatureJsonLd({
     "isPartOf": {
       "@type": "WebSite",
       "name": "WePlanify",
-      "url": "https://weplanify.com"
+      "url": SITE_URL
     },
     "about": {
       "@type": "SoftwareApplication",
@@ -55,7 +63,7 @@ export default function FeatureJsonLd({
     }
   };
 
-  // BreadcrumbList Schema
+  // BreadcrumbList Schema — Home > Feature (no /features index page exists)
   const breadcrumbSchema = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
@@ -63,18 +71,12 @@ export default function FeatureJsonLd({
       {
         "@type": "ListItem",
         "position": 1,
-        "name": "Accueil",
-        "item": "https://weplanify.com"
+        "name": homeLabel,
+        "item": `${SITE_URL}/${locale}`
       },
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "Features",
-        "item": "https://weplanify.com/features"
-      },
-      {
-        "@type": "ListItem",
-        "position": 3,
         "name": featureName,
         "item": featureUrl
       }


### PR DESCRIPTION
Feature pages emitted WebPage/BreadcrumbList JSON-LD pointing to non-canonical URLs (https://weplanify.com/features/<slug>) — missing the www host and the /<locale> segment, so the structured-data URLs never matched the page canonical (https://www.weplanify.com/<locale>/features/<slug>). The breadcrumb also hardcoded the French label "Accueil" on EN pages and linked an intermediate "Features" item to /features, which has no index page (404).

FeatureJsonLd now takes locale + slug and builds the canonical URL itself, localizes the Home/Accueil label, and drops the dead /features breadcrumb level (Home > Feature). Updated all 9 feature call sites.