### PR TITLE
fix(seo): de-cannibalize 'group trip planner' (RDM-74)

### DIFF
--- a/src/app/[locale]/alternatives/best-group-trip-planner-apps/page.tsx
+++ b/src/app/[locale]/alternatives/best-group-trip-planner-apps/page.tsx
@@ -45,15 +45,15 @@ const PATHNAME = "/alternatives/best-group-trip-planner-apps";
 
 const meta = {
   en: {
-    title: "10 Best Group Trip Planner Apps 2026: Wanderlog, TripIt & More",
+    title: "Best Group Trip Planner Apps Compared (2026): Wanderlog, TripIt & More",
     description:
-      "We tested 10 group trip planner apps side-by-side: Wanderlog, TripIt, Splitwise, Stippl, SquadTrip & more. Compare prices, features, pros & cons in 2 minutes.",
+      "Our 2026 comparison of 10 group trip planner apps side-by-side: Wanderlog, TripIt, Splitwise, Stippl, SquadTrip & more. Compare prices, features, pros & cons in 2 minutes.",
   },
   fr: {
     title:
-      "Les 10 Meilleures Applis pour Organiser un Voyage de Groupe (2026)",
+      "Comparatif 2026 : les meilleures applis pour un voyage de groupe",
     description:
-      "On a testé les meilleures applis de voyage de groupe. Comparatif honnête : itinéraire, budget, sondages, collaboration. Notre verdict 2026.",
+      "Notre comparatif 2026 des meilleures applis de voyage de groupe, testées côte à côte : itinéraire, budget, sondages, collaboration. Notre verdict.",
   },
 };
 
@@ -98,7 +98,7 @@ const content = {
   en: {
     heroTag: "Complete Guide",
     readTime: "12 min read",
-    h1: "10 Best Group Trip Planner Apps in 2026",
+    h1: "The 10 Best Group Trip Planner Apps Compared (2026)",
     intro:
       "Planning a group trip is notoriously difficult. Between coordinating schedules, splitting costs, voting on destinations, and building an itinerary that works for everyone, you need the right tools. We tested and compared the most popular group travel planning apps available in 2026 to help you pick the one that fits your crew. Here are our top 10, ranked by overall usefulness for group travel.",
 
@@ -362,7 +362,7 @@ const content = {
   fr: {
     heroTag: "Guide Complet",
     readTime: "12 min de lecture",
-    h1: "Les 10 Meilleures Applications pour Organiser un Voyage de Groupe en 2026",
+    h1: "Comparatif 2026 : les 10 meilleures applis pour un voyage de groupe",
     intro:
       "Organiser un voyage de groupe est notoirement difficile. Entre la coordination des agendas, le partage des frais, le vote sur les destinations et la construction d'un itinéraire qui convient à tout le monde, il te faut les bons outils. On a testé et comparé les applications de planification de voyage de groupe les plus populaires disponibles en 2026 pour t'aider à choisir celle qui convient à ton groupe. Voici notre top 10, classé par utilité globale pour les voyages de groupe.",
 

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -7,14 +7,14 @@ const SITE_URL = "https://www.weplanify.com";
 
 const localizedDefaults: Record<string, { title: string; description: string }> = {
   en: {
-    title: "WePlanify — Free Group Trip Planner for Friends",
+    title: "WePlanify — Free Group Trip Planner App for Friends",
     description:
-      "The collaborative group trip planner: shared itinerary, group polls, shared budget and packing lists. Free, bilingual, built for trips with friends.",
+      "The collaborative group trip planner app: shared itinerary, group polls, shared budget and packing lists. Free, bilingual, built for trips with friends.",
   },
   fr: {
-    title: "WePlanify — Planificateur gratuit de voyages de groupe",
+    title: "WePlanify — L'appli gratuite pour planifier un voyage de groupe",
     description:
-      "Le planificateur collaboratif pour vos voyages entre amis : itinéraire partagé, sondages, budget commun, listes de bagages. Gratuit, en français.",
+      "L'appli collaborative pour vos voyages entre amis : itinéraire partagé, sondages, budget commun, listes de bagages. Gratuite, en français.",
   },
 };
 


### PR DESCRIPTION
## Ticket
RDM-74 — SEO: Fixer cannibalisation 'group trip planner' entre homepage et /alternatives (P0).

## Diagnostic (GSC, via le ticket)
`group trip planner` rankait sur **deux** pages : la homepage (`/fr`, pos ~3) **et** `/alternatives/best-group-trip-planner-apps` (pos ~24). Le listicle diluait l'autorité de la homepage sur le terme principal.

> Note : GSC est actuellement en erreur d'auth (`invalid_rapt`, refresh ADC requis) et aucun SERP API n'est configuré, donc je n'ai pas pu re-tirer les positions fraîches. Le fix suit le diagnostic documenté dans le ticket — à revérifier dans GSC une fois l'auth rétablie.

## Changement (différenciation d'intention)
- **Homepage** (`src/lib/metadata.ts`) → cible « group trip planner **app** » (l'outil) : ajout de "App"/"appli" dans le title + description EN/FR.
- **`/alternatives/best-group-trip-planner-apps`** → pivote vers l'intention **comparatif** « best group trip planner apps comparison 2026 » : title, H1 et meta description mènent désormais avec "Compared / Comparatif 2026" au lieu du terme nu.

## Vérif
- `tsc --noEmit` : OK

## Suivi
- Rouvrir GSC sous 2-4 semaines pour confirmer que la homepage récupère le terme et que le listicle ne ranke plus que sur l'intention comparatif.
- Surveiller un éventuel chevauchement résiduel entre `/alternatives` ("Best Group Trip Planning Apps Compared") et cette page (hors scope RDM-74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)