### PR TITLE
feat(attribution): first-touch — garder l'utm_source d'origine (Insta/TikTok) jusqu'au signup

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,6 +4,8 @@ import "../globals.css";
 import { generateMetadataFromSanity } from "@/lib/metadata";
 import { Analytics } from "@/components/Analytics";
 import { PageViewTracker } from "@/lib/analytics/page-view-tracker";
+import { FirstTouchTracker } from "@/lib/attribution/first-touch-tracker";
+import { FirstTouchLinkRewriter } from "@/lib/attribution/first-touch-link-rewriter";
 import CookieConsent from "@/components/CookieConsent";
 import StickyCTA from "@/components/StickyCTA";
 import { StructuredData } from "@/components/StructuredData";
@@ -100,6 +102,10 @@ export default async function LocaleLayout({ children, params }: Props) {
         <Analytics />
         {/* Tracks SPA navigations as page_view events */}
         <PageViewTracker />
+        {/* Captures first-touch campaign source (utm_*) and persists it for the visit */}
+        <FirstTouchTracker />
+        {/* Rewrites in-content register CTAs to the first-touch source at click time */}
+        <FirstTouchLinkRewriter />
       </body>
     </html>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { Footer as FooterType } from "@/sanity/lib/type";
 import { useState } from "react";
 import { trackEvent } from "@/lib/tracking";
+import { useRegisterHref } from "@/lib/attribution/use-register-href";
 
 function SocialIcon({ platform }: { platform: string }) {
   const name = platform.toLowerCase();
@@ -89,6 +90,7 @@ export default function Footer({ footerData }: FooterProps) {
   const [isSubscribed, setIsSubscribed] = useState(false);
   const pathname = usePathname();
   const locale = pathname?.startsWith("/fr") ? "fr" : "en";
+  const registerFallback = useRegisterHref({ locale, medium: "footer" });
 
   const featuresColumn = {
     title: locale === "fr" ? "Fonctionnalités" : "Features",
@@ -279,7 +281,7 @@ export default function Footer({ footerData }: FooterProps) {
                 </p>
               )}
               {footerData.ctaSection.buttonText && (
-                <Link href={footerData.ctaSection.buttonUrl || `https://app.weplanify.com/${locale}/register?utm_source=landing`}>
+                <Link href={footerData.ctaSection.buttonUrl || registerFallback}>
                   <button className="bg-[#F6391A] text-white px-6 py-2.5 rounded-full font-karla font-bold text-base hover:bg-[#F6391A]/90 transition-colors w-fit">
                     {footerData.ctaSection.buttonText}
                   </button>

--- a/src/components/MobileCTASection.tsx
+++ b/src/components/MobileCTASection.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { PulsatingButton } from "@/components/magicui/pulsating-button";
 import { CtaType, Organization } from "@/sanity/lib/type";
+import { useRegisterHref } from "@/lib/attribution/use-register-href";
 
 interface MobileCTASectionProps {
   ctaData: CtaType;
@@ -14,11 +15,12 @@ interface MobileCTASectionProps {
 export default function MobileCTASection({ ctaData, organization }: MobileCTASectionProps) {
   const pathname = usePathname();
   const locale = pathname?.split("/")[1] === "fr" ? "fr" : "en";
+  const registerFallback = useRegisterHref({ locale, medium: "mobile-cta" });
   return (
     <section className="mt-12 lg:hidden flex flex-col justify-center items-center" aria-labelledby="mobile-cta-title">
       <h2 id="mobile-cta-title" className="sr-only">Mobile actions</h2>
       <div className="flex gap-6 items-center flex-col lg:flex-row w-full">
-        <Link href={ctaData.buttonUrl || `https://app.weplanify.com/${locale}/register?utm_source=landing`} className={"w-full"} rel="nofollow">
+        <Link href={ctaData.buttonUrl || registerFallback} className={"w-full"} rel="nofollow">
           <PulsatingButton className="w-4/5 mx-auto lg:w-full text-nowrap">
             {ctaData.buttonText}
           </PulsatingButton>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,6 +2,7 @@
 import { NavType, Navigation } from "@/sanity/lib/type";
 import Image from "next/image";
 import Link from "next/link";
+import { useRegisterHref } from "@/lib/attribution/use-register-href";
 import { PulsatingButton } from "./magicui/pulsating-button";
 import { useState } from "react";
 import { usePathname } from "next/navigation";
@@ -176,7 +177,7 @@ export default function Nav({ navData }: NavProps) {
   const locale: Locale = pathname?.startsWith("/fr") ? "fr" : "en";
   const nav = navData || DEFAULT_NAV_DATA;
   const loginUrl = `https://app.weplanify.com/${locale}/login`;
-  const registerUrl = `https://app.weplanify.com/${locale}/register?utm_source=landing`;
+  const registerUrl = useRegisterHref({ locale, medium: "nav" });
 
   const toggleMenu = () => {
     setIsMenuOpen((prev) => {

--- a/src/components/OrganizationSection.tsx
+++ b/src/components/OrganizationSection.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { PulsatingButtonWhite } from "@/components/magicui/pulsating-button-white-black";
 import { CtaType, Organization } from "@/sanity/lib/type";
 import Org from "@/components/Org";
+import { useRegisterHref } from "@/lib/attribution/use-register-href";
 
 interface OrganizationSectionProps {
   organization: Organization;
@@ -15,6 +16,7 @@ interface OrganizationSectionProps {
 export default function OrganizationSection({ organization, ctaData }: OrganizationSectionProps) {
   const pathname = usePathname();
   const locale = pathname?.split("/")[1] === "fr" ? "fr" : "en";
+  const registerFallback = useRegisterHref({ locale, medium: "organization" });
   return (
     <section id="fonctionnement" className="relative pb-28 flex flex-col items-center justify-center bg-[#4D9F79]">
       <Image
@@ -64,7 +66,7 @@ export default function OrganizationSection({ organization, ctaData }: Organizat
       <Org data={organization.featuresList} />
       <div className="flex flex-col items-center justify-center mt-10 lg:mt-4">
         <div className="flex gap-6 items-center flex-col lg:flex-row w-full">
-          <Link href={ctaData.buttonUrl || `https://app.weplanify.com/${locale}/register?utm_source=landing`} className={"w-full"} rel="nofollow">
+          <Link href={ctaData.buttonUrl || registerFallback} className={"w-full"} rel="nofollow">
             <PulsatingButtonWhite className="w-4/5 mx-auto lg:w-full text-nowrap">
               {ctaData.buttonText}
             </PulsatingButtonWhite>

--- a/src/components/StackingCards.tsx
+++ b/src/components/StackingCards.tsx
@@ -4,12 +4,10 @@ import { useRef } from "react";
 import { motion, useScroll, useTransform, useInView } from "framer-motion";
 import Link from "next/link";
 import { AiGlobeJourney, LiveCollaboration, LiveVoting } from "@/components/animations";
+import { useRegisterHref } from "@/lib/attribution/use-register-href";
 
 type Lang = "en" | "fr";
 type AnimationType = "ai-globe" | "live-collaboration" | "live-voting";
-
-const getRegisterUrl = (locale: string) =>
-  `https://app.weplanify.com/${locale}/register?utm_source=landing`;
 
 interface CardData {
   imagePosition: "left" | "right";
@@ -118,6 +116,7 @@ interface StackingCardsProps {
 }
 
 function Card({ card, index, locale }: { card: CardData; index: number; locale: string }) {
+  const registerUrl = useRegisterHref({ locale, medium: "stacking-cards" });
   const containerRef = useRef<HTMLDivElement>(null);
   const animationRef = useRef<HTMLDivElement>(null);
   // amount: 0.1 fires once 10% of the animation panel is visible, which is
@@ -181,7 +180,7 @@ function Card({ card, index, locale }: { card: CardData; index: number; locale: 
           </div>
         )}
 
-        <Link href={getRegisterUrl(locale)} rel="nofollow">
+        <Link href={registerUrl} rel="nofollow">
           <button
             className="px-8 py-3 rounded-full font-karla font-bold text-sm lg:text-base hover:opacity-90 transition-all ring-4"
             style={{

--- a/src/components/StickyCTA.tsx
+++ b/src/components/StickyCTA.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 import { PulsatingButton } from "@/components/magicui/pulsating-button";
 import { trackEvent } from "@/lib/tracking";
 import { travelGuideSlugIndex, type TravelGuideLocale } from "@/lib/travel-guides/slugs";
+import { buildRegisterHref } from "@/lib/attribution/first-touch";
 
 interface StickyCTAProps {
   text: string;
@@ -36,12 +37,20 @@ export default function StickyCTA({ text, href }: StickyCTAProps) {
   const travelGuideTemplate = travelGuideMatch
     ? travelGuideSlugIndex[locale as TravelGuideLocale]?.[travelGuideMatch[1]]
     : undefined;
-  const defaultHref = match
-    ? `https://app.weplanify.com/${locale}/register?utm_source=landing&utm_campaign=${match.campaign}&template=${match.template}`
-    : travelGuideTemplate
-      ? `https://app.weplanify.com/${locale}/register?template=${travelGuideTemplate}&utm_source=landing&utm_medium=travel-guide&utm_campaign=${travelGuideTemplate}`
-      : `https://app.weplanify.com/${locale}/register?utm_source=landing`;
-  const targetHref = href ?? defaultHref;
+  const computeHref = () => {
+    if (href) return href;
+    if (match) return buildRegisterHref({ locale, template: match.template, campaign: match.campaign });
+    if (travelGuideTemplate)
+      return buildRegisterHref({ locale, template: travelGuideTemplate, medium: "travel-guide", campaign: travelGuideTemplate });
+    return buildRegisterHref({ locale });
+  };
+  // Recomputed after mount so first-touch attribution (localStorage) is applied;
+  // the sticky CTA only renders post-scroll, well after hydration.
+  const [targetHref, setTargetHref] = useState(computeHref);
+  useEffect(() => {
+    setTargetHref(computeHref());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, href]);
   const [show, setShow] = useState(false);
   const [cookieBannerHeight, setCookieBannerHeight] = useState(0);
 

--- a/src/lib/attribution/first-touch-link-rewriter.tsx
+++ b/src/lib/attribution/first-touch-link-rewriter.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect } from "react";
+import { readFirstTouch } from "@/lib/attribution/first-touch";
+
+/**
+ * Safety net for first-touch attribution on the long tail of in-content CTAs.
+ *
+ * Most register links live in page bodies and are hardcoded to
+ * `utm_source=landing` — the right default for a direct/organic visitor. But a
+ * visitor who arrived from an external campaign (Instagram/TikTok) must keep
+ * that original source. Rather than thread attribution through dozens of CTAs,
+ * this listener rewrites the `utm_*` of any register link at click time, and
+ * only when a first-touch source was actually captured.
+ *
+ * Register links point to `app.weplanify.com` (a different origin), so they are
+ * plain `<a>` navigations — mutating `href` just before the browser follows it
+ * is reliable. We hook `pointerdown` (fires before navigation for left, middle
+ * and modifier clicks) with `click` as a fallback; the rewrite is idempotent.
+ */
+export function FirstTouchLinkRewriter() {
+	useEffect(() => {
+		const rewrite = (event: Event) => {
+			const target = event.target;
+			if (!(target instanceof Element)) return;
+
+			const anchor = target.closest<HTMLAnchorElement>('a[href*="app.weplanify.com"]');
+			if (!anchor) return;
+
+			let url: URL;
+			try {
+				url = new URL(anchor.href);
+			} catch {
+				return;
+			}
+			if (url.hostname !== "app.weplanify.com" || !url.pathname.endsWith("/register")) return;
+
+			const ft = readFirstTouch();
+			if (!ft.utm_source) return; // no external first-touch — keep the page default
+
+			url.searchParams.set("utm_source", ft.utm_source);
+			if (ft.utm_medium) url.searchParams.set("utm_medium", ft.utm_medium);
+			else url.searchParams.delete("utm_medium");
+			if (ft.utm_campaign) url.searchParams.set("utm_campaign", ft.utm_campaign);
+			else url.searchParams.delete("utm_campaign");
+			// signup_source and template are left untouched.
+
+			anchor.href = url.toString();
+		};
+
+		document.addEventListener("pointerdown", rewrite, true);
+		document.addEventListener("click", rewrite, true);
+		return () => {
+			document.removeEventListener("pointerdown", rewrite, true);
+			document.removeEventListener("click", rewrite, true);
+		};
+	}, []);
+
+	return null;
+}

--- a/src/lib/attribution/first-touch-tracker.tsx
+++ b/src/lib/attribution/first-touch-tracker.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { captureFirstTouch } from "@/lib/attribution/first-touch";
+
+function FirstTouchTrackerInner() {
+	const searchParams = useSearchParams();
+
+	useEffect(() => {
+		captureFirstTouch(searchParams);
+	}, [searchParams]);
+
+	return null;
+}
+
+/**
+ * Captures the external campaign source (utm_*) on the first page the visitor
+ * lands on and persists it for the rest of the visit. Mount once in the root
+ * layout. Wrapped in Suspense because `useSearchParams()` requires it during
+ * static rendering.
+ */
+export function FirstTouchTracker() {
+	return (
+		<Suspense fallback={null}>
+			<FirstTouchTrackerInner />
+		</Suspense>
+	);
+}

--- a/src/lib/attribution/first-touch.ts
+++ b/src/lib/attribution/first-touch.ts
@@ -1,0 +1,123 @@
+/**
+ * First-touch attribution.
+ *
+ * A visitor who arrives from an external campaign (e.g. an Instagram bio link
+ * `weplanify.com/?utm_source=instagram`) must keep that source all the way to
+ * `app.weplanify.com/register`, even after clicking internal CTAs that would
+ * otherwise overwrite it with `utm_source=landing`.
+ *
+ * Two facts drive the design:
+ *  1. localStorage is origin-scoped — the landing (`weplanify.com`) and the app
+ *     (`app.weplanify.com`) do NOT share it. So the landing persists the
+ *     original UTMs locally for the duration of the visit, and forwards them to
+ *     the app via the register URL querystring (the only cross-origin channel).
+ *  2. Attribution is "first-touch": once captured, the external source is never
+ *     overwritten by a later visit or an internal click.
+ *
+ * Model (option B):
+ *  - `utm_*`        = the external acquisition source (instagram / tiktok / …),
+ *                     or `landing` as a fallback for direct/organic visits.
+ *  - `signup_source` = the internal placement where the user converted
+ *                     (e.g. `landing:world-cup-2026:hero`), always set.
+ */
+
+export type Attribution = {
+	utm_source?: string;
+	utm_medium?: string;
+	utm_campaign?: string;
+};
+
+const STORAGE_KEY = 'wp_first_touch';
+const MAX = 128;
+
+const clean = (value: string | null | undefined): string | undefined => {
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	return trimmed === '' ? undefined : trimmed.slice(0, MAX);
+};
+
+const hasWindow = (): boolean => typeof window !== 'undefined';
+
+/** Read the persisted first-touch attribution (client-only; {} on the server). */
+export const readFirstTouch = (): Attribution => {
+	if (!hasWindow()) return {};
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		return raw ? (JSON.parse(raw) as Attribution) : {};
+	} catch {
+		return {};
+	}
+};
+
+/**
+ * Persist the UTMs from the current URL — but only the FIRST time we see any.
+ * Subsequent visits (even with different UTMs) are ignored, so the original
+ * source wins. A visit with no UTM at all stores nothing.
+ */
+export const captureFirstTouch = (params: URLSearchParams | null): void => {
+	if (!hasWindow() || !params) return;
+
+	const incoming: Attribution = {
+		utm_source: clean(params.get('utm_source')),
+		utm_medium: clean(params.get('utm_medium')),
+		utm_campaign: clean(params.get('utm_campaign')),
+	};
+
+	if (!incoming.utm_source) return; // nothing meaningful to capture
+	if (readFirstTouch().utm_source) return; // first-touch already set — keep it
+
+	try {
+		const stored: Attribution = {};
+		if (incoming.utm_source) stored.utm_source = incoming.utm_source;
+		if (incoming.utm_medium) stored.utm_medium = incoming.utm_medium;
+		if (incoming.utm_campaign) stored.utm_campaign = incoming.utm_campaign;
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+	} catch {
+		// ignore quota / private-mode errors
+	}
+};
+
+export type RegisterHrefOptions = {
+	locale: string;
+	/** Product param: pre-seed a trip template at signup. Not attribution. */
+	template?: string;
+	/** Internal placement context — feeds signup_source, and utm_* as fallback. */
+	campaign?: string;
+	medium?: string;
+	placement?: string;
+};
+
+const APP_REGISTER = 'https://app.weplanify.com';
+
+/**
+ * Build the register URL on the app subdomain, injecting first-touch
+ * attribution. If an external source was captured it wins on `utm_*`; otherwise
+ * we fall back to `utm_source=landing` plus the page's own medium/campaign.
+ * `signup_source` always carries the internal placement context.
+ */
+export const buildRegisterHref = (opts: RegisterHrefOptions): string => {
+	const { locale, template, campaign, medium, placement } = opts;
+	const ft = readFirstTouch();
+
+	const query = new URLSearchParams();
+
+	if (ft.utm_source) {
+		// External first-touch source wins.
+		query.set('utm_source', ft.utm_source);
+		if (ft.utm_medium) query.set('utm_medium', ft.utm_medium);
+		if (ft.utm_campaign) query.set('utm_campaign', ft.utm_campaign);
+	} else {
+		// Direct / organic landing visit.
+		query.set('utm_source', 'landing');
+		if (medium) query.set('utm_medium', medium);
+		if (campaign) query.set('utm_campaign', campaign);
+	}
+
+	// Internal placement, regardless of external source.
+	const contextParts = ['landing', campaign ?? medium, placement].filter(Boolean);
+	query.set('signup_source', contextParts.join(':'));
+
+	if (template) query.set('template', template);
+
+	return `${APP_REGISTER}/${locale}/register?${query.toString()}`;
+};

--- a/src/lib/attribution/use-register-href.ts
+++ b/src/lib/attribution/use-register-href.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { buildRegisterHref, type RegisterHrefOptions } from "./first-touch";
+
+/**
+ * Returns the app register href with first-touch attribution applied.
+ *
+ * Computed once for SSR (localStorage unavailable → `utm_source=landing`
+ * fallback) and recomputed after mount, when the persisted first-touch source
+ * is readable. Use in client components that own a register CTA (Nav, Footer,
+ * StickyCTA, …). In-content page CTAs are handled globally by
+ * FirstTouchLinkRewriter instead.
+ */
+export function useRegisterHref(opts: RegisterHrefOptions): string {
+	const [href, setHref] = useState(() => buildRegisterHref(opts));
+
+	useEffect(() => {
+		setHref(buildRegisterHref(opts));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [opts.locale, opts.template, opts.campaign, opts.medium, opts.placement]);
+
+	return href;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,7 +24,11 @@ function pickLocaleFromAcceptLanguage(header: string | null): 'fr' | 'en' {
 export default function middleware(request: NextRequest) {
   if (request.nextUrl.pathname === '/') {
     const locale = pickLocaleFromAcceptLanguage(request.headers.get('accept-language'));
-    const response = NextResponse.redirect(new URL(`/${locale}`, request.url), 302);
+    const target = new URL(`/${locale}`, request.url);
+    // Preserve the querystring (utm_source=… etc.) across the locale redirect so
+    // first-touch attribution survives the `/` → `/{locale}` hop.
+    target.search = request.nextUrl.search;
+    const response = NextResponse.redirect(target, 302);
     // Vary on Accept-Language so /en and /fr each get a fair shot at being the
     // canonical for their locale instead of one being a permanent redirect target.
     response.headers.set('Vary', 'Accept-Language');


### PR DESCRIPTION
## Problème
Un visiteur arrivant via `weplanify.com/?utm_source=instagram` perdait sa source : (1) le middleware `/`→`/{locale}` jetait la query ; (2) les CTA register hardcodent `utm_source=landing` qui écrasait l'origine ; (3) le localStorage n'est pas partagé entre `weplanify.com` et `app.weplanify.com`. Tout le trafic social remontait en `landing`.

## Solution — attribution first-touch
- **`first-touch.ts`** : capture l'`utm_*` à la 1ʳᵉ visite, persiste **uniquement si vide** (l'original gagne) ; `buildRegisterHref()` (option B : `utm_*` = source externe, fallback `landing` ; `signup_source` = contexte interne).
- **`FirstTouchTracker`** : capture sur la 1ʳᵉ page (monté dans le layout).
- **`FirstTouchLinkRewriter`** : réécrit l'`utm_source` des CTA register in-content au clic, **seulement si** un first-touch existe → pas besoin d'éditer les 33 pages, le `utm_source=landing` hardcodé devient le bon fallback pour les visites directes.
- **`useRegisterHref`** : appliqué aux CTA du chrome global (Nav, Footer, StickyCTA, MobileCTA, OrganizationSection, StackingCards).
- **`middleware.ts`** : conserve la query string au redirect de locale.

À coupler avec la PR `frontend` (merge inversé du hook `useSignupAttribution`).

## Vérif
tsc + eslint OK sur les fichiers touchés. `next build` complet non lancé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)