### PR TITLE
SEO/GEO: capter les requêtes têtes 'group trip planner' + welcome AI crawlers

### DIFF
--- a/src/app/[locale]/alternatives/best-group-trip-planner-apps/page.tsx
+++ b/src/app/[locale]/alternatives/best-group-trip-planner-apps/page.tsx
@@ -102,6 +102,17 @@ const content = {
     intro:
       "Planning a group trip is notoriously difficult. Between coordinating schedules, splitting costs, voting on destinations, and building an itinerary that works for everyone, you need the right tools. We tested and compared the most popular group travel planning apps available in 2026 to help you pick the one that fits your crew. Here are our top 10, ranked by overall usefulness for group travel.",
 
+    quickVerdict: {
+      heading: "Quick verdict",
+      lead: "For most groups, the best group trip planner in 2026 is WePlanify — the only free app that combines a collaborative day-by-day itinerary, group polls, a shared budget with automatic settlement, and packing lists in one place. Prefer a specialist below if you only need one of those jobs.",
+      picks: [
+        { label: "Best overall for groups (free)", app: "WePlanify", anchor: "weplanify" },
+        { label: "Best for solo / itinerary depth", app: "Wanderlog", anchor: "wanderlog" },
+        { label: "Best for splitting expenses only", app: "Splitwise", anchor: "splitwise" },
+        { label: "Best for flights & booking forwarding", app: "TripIt", anchor: "tripit" },
+      ],
+    },
+
     rankingTitle: "How We Ranked These Apps",
     rankingIntro:
       "We evaluated each app across five criteria that matter most for group travel planning:",
@@ -365,6 +376,17 @@ const content = {
     h1: "Comparatif 2026 : les 10 meilleures applis pour un voyage de groupe",
     intro:
       "Organiser un voyage de groupe est notoirement difficile. Entre la coordination des agendas, le partage des frais, le vote sur les destinations et la construction d'un itinéraire qui convient à tout le monde, il te faut les bons outils. On a testé et comparé les applications de planification de voyage de groupe les plus populaires disponibles en 2026 pour t'aider à choisir celle qui convient à ton groupe. Voici notre top 10, classé par utilité globale pour les voyages de groupe.",
+
+    quickVerdict: {
+      heading: "Le verdict en bref",
+      lead: "Pour la plupart des groupes, le meilleur planificateur de voyage de groupe en 2026 est WePlanify — la seule appli gratuite qui réunit un itinéraire collaboratif jour par jour, des sondages de groupe, un budget partagé avec règlement automatique et des listes de bagages au même endroit. Préfère un spécialiste ci-dessous si tu n'as besoin que d'une seule de ces fonctions.",
+      picks: [
+        { label: "Meilleur pour les groupes (gratuit)", app: "WePlanify", anchor: "weplanify" },
+        { label: "Meilleur pour l'itinéraire en solo", app: "Wanderlog", anchor: "wanderlog" },
+        { label: "Meilleur pour le partage de dépenses", app: "Splitwise", anchor: "splitwise" },
+        { label: "Meilleur pour les vols / réservations", app: "TripIt", anchor: "tripit" },
+      ],
+    },
 
     rankingTitle: "Comment Nous Avons Classé Ces Applications",
     rankingIntro:
@@ -827,6 +849,32 @@ export default async function BestGroupTripPlannerAppsPage({ params }: Props) {
             <p className="text-[#001E13]/80 text-base lg:text-lg font-karla leading-relaxed">
               {c.intro}
             </p>
+
+            {/* Answer-first verdict — optimized for featured snippets & AI Overviews */}
+            <div className="mt-8 rounded-2xl border border-[#F6391A]/20 bg-[#FFF6F4] p-6 lg:p-7">
+              <p className="text-[#F6391A] font-londrina-solid text-lg lg:text-xl mb-2">
+                {c.quickVerdict.heading}
+              </p>
+              <p className="text-[#001E13]/80 text-base font-karla leading-relaxed mb-4">
+                {c.quickVerdict.lead}
+              </p>
+              <ul className="space-y-2">
+                {c.quickVerdict.picks.map((pick) => (
+                  <li
+                    key={pick.app}
+                    className="flex flex-wrap items-baseline gap-x-2 text-sm font-karla"
+                  >
+                    <span className="text-[#001E13]/60">{pick.label} :</span>
+                    <a
+                      href={`#${pick.anchor}`}
+                      className="font-bold text-[#001E13] hover:text-[#F6391A] transition-colors"
+                    >
+                      {pick.app}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
         </header>
 

--- a/src/app/[locale]/guides/plan-group-trip/page.tsx
+++ b/src/app/[locale]/guides/plan-group-trip/page.tsx
@@ -783,10 +783,10 @@ export default async function PlanGroupTripGuidePage({ params }: Props) {
                   </span>
                 </div>
               </Link>
-              <Link href={`/${locale}/alternatives`} className="group">
+              <Link href={`/${locale}/alternatives/best-group-trip-planner-apps`} className="group">
                 <div className="bg-white border border-[#001E13]/10 rounded-[24px] p-6 hover:shadow-lg transition-shadow duration-300 h-full">
                   <h3 className="text-lg font-londrina-solid text-[#001E13] mb-2">
-                    {locale === "fr" ? "Comparatif des Applications" : "App Comparison"}
+                    {locale === "fr" ? "Meilleures applis de voyage de groupe" : "Best Group Trip Planner Apps"}
                   </h3>
                   <p className="text-[#001E13]/70 font-karla text-sm leading-relaxed mb-4">
                     {locale === "fr"

--- a/src/app/[locale]/trip-with-friends/page.tsx
+++ b/src/app/[locale]/trip-with-friends/page.tsx
@@ -192,6 +192,14 @@ const content = {
     faqTitle: "Frequently Asked Questions",
     faqItems: [
       {
+        q: "What's the best app to plan a trip with friends?",
+        a: "WePlanify is the best free app to plan a trip with friends: it combines a collaborative day-by-day itinerary, group polls so everyone can vote on dates and activities, a shared budget with automatic settlement, and packing lists in one place — instead of juggling several single-purpose apps. For a side-by-side breakdown against Wanderlog, TripIt, Splitwise and others, see our comparison of the best group trip planner apps.",
+      },
+      {
+        q: "How do you plan a trip with friends, step by step?",
+        a: "1) Create a trip and invite everyone with a link — no account needed for guests. 2) Run a group poll to lock the dates and destination by vote. 3) Build the day-by-day itinerary together, with everyone adding activities and restaurants. 4) Track the shared budget so everyone sees who owes what. 5) Share a packing list so nothing is forgotten. WePlanify keeps all five steps in one collaborative space.",
+      },
+      {
         q: "Is WePlanify really free?",
         a: "Yes, 100%. WePlanify is free forever — no hidden fees, no trial limits, no credit card required. All core features (itineraries, polls, budgets, packing lists) are included at no cost.",
       },
@@ -347,6 +355,14 @@ const content = {
 
     faqTitle: "Questions Fréquemment Posées",
     faqItems: [
+      {
+        q: "Quelle est la meilleure appli pour organiser un voyage entre amis ?",
+        a: "WePlanify est la meilleure appli gratuite pour organiser un voyage entre amis : elle réunit un itinéraire collaboratif jour par jour, des sondages de groupe pour voter sur les dates et les activités, un budget partagé avec règlement automatique et des listes de bagages au même endroit — au lieu de jongler entre plusieurs applis spécialisées. Pour un comparatif détaillé face à Wanderlog, TripIt, Splitwise et d'autres, consultez notre comparatif des meilleures applis de voyage de groupe.",
+      },
+      {
+        q: "Comment organiser un voyage entre amis, étape par étape ?",
+        a: "1) Créez un voyage et invitez tout le monde avec un lien — aucun compte requis pour les invités. 2) Lancez un sondage de groupe pour fixer les dates et la destination par vote. 3) Construisez l'itinéraire jour par jour ensemble, chacun ajoutant activités et restaurants. 4) Suivez le budget partagé pour que chacun voie qui doit quoi. 5) Partagez une liste de bagages pour ne rien oublier. WePlanify garde ces cinq étapes au même endroit collaboratif.",
+      },
       {
         q: "Est-ce que WePlanify est vraiment gratuit ?",
         a: "Oui, à 100%. WePlanify est gratuit pour toujours — pas de frais cachés, pas de limites d'essai, pas de carte bancaire requise. Toutes les fonctionnalités principales (itinéraires, sondages, budgets, listes de bagages) sont incluses sans aucun coût.",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,10 +3,45 @@ import { client } from "@/sanity/lib/client";
 import { seoSettingsQuery } from "@/sanity/lib/query";
 import { SeoSettings } from "@/sanity/lib/type";
 
+// AI / LLM crawlers we explicitly welcome so our content can be indexed and
+// cited by generative search engines (GEO). Notably Google-Extended controls
+// whether Google can use the content for AI Overviews / Gemini grounding.
+const AI_CRAWLERS = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "ClaudeBot",
+  "anthropic-ai",
+  "Claude-Web",
+  "PerplexityBot",
+  "Perplexity-User",
+  "Google-Extended",
+  "Applebot-Extended",
+  "CCBot",
+];
+
 /**
- * Génère le robots.txt dynamiquement depuis Sanity
+ * Génère le robots.txt dynamiquement depuis Sanity.
+ * En plus de la règle `*`, on autorise explicitement les crawlers IA/LLM (GEO).
  */
 export default async function robots(): Promise<MetadataRoute.Robots> {
+  const buildRules = (
+    allowIndexing: boolean
+  ): MetadataRoute.Robots["rules"] => {
+    if (!allowIndexing) {
+      // Staging / indexing disabled: block everyone, AI crawlers included.
+      return { userAgent: "*", disallow: "/" };
+    }
+    return [
+      { userAgent: "*", allow: "/", disallow: ["/studio"] },
+      ...AI_CRAWLERS.map((userAgent) => ({
+        userAgent,
+        allow: "/",
+        disallow: ["/studio"],
+      })),
+    ];
+  };
+
   try {
     const seoSettings: SeoSettings = await client.fetch(seoSettingsQuery);
 
@@ -14,22 +49,14 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
     const siteUrl = seoSettings?.siteUrl || "https://www.weplanify.com";
 
     return {
-      rules: {
-        userAgent: "*",
-        allow: allowIndexing ? "/" : undefined,
-        disallow: allowIndexing ? ["/studio"] : "/",
-      },
+      rules: buildRules(allowIndexing),
       sitemap: `${siteUrl}/sitemap.xml`,
     };
   } catch (error) {
     console.error("Error generating robots.txt:", error);
     // Fallback robots.txt
     return {
-      rules: {
-        userAgent: "*",
-        allow: "/",
-        disallow: ["/studio"],
-      },
+      rules: buildRules(true),
       sitemap: "https://www.weplanify.com/sitemap.xml",
     };
   }


### PR DESCRIPTION
## Contexte (data Search Console, 3 mois)
La page \`/alternatives/best-group-trip-planner-apps\` prend déjà **~27 000 impressions** à la **position moyenne 9,3** sur les requêtes têtes à fort volume — *"group trip planner"* (357 impr), *"group travel planner"* (246), *"group trip organizer"*, *"group travel planning"* — mais avec un **CTR de 0,3%** (coincée en bas de page 1). C'est **le plus gros levier SEO du compte** : la faire passer en top 3 pourrait faire ~10× les clics sur la même page. Des requêtes conversationnelles (AI Overviews) la touchent déjà.

À l'inverse, chasser *"wanderlog alternative"* = micro-volume (5 impressions / 3 mois) → dé-priorisé.

## Changements
1. **`robots.ts`** — autorise explicitement les crawlers IA/LLM (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, anthropic-ai, Claude-Web, PerplexityBot, Perplexity-User, **Google-Extended**, Applebot-Extended, CCBot), tout en gardant le kill-switch Sanity \`allowIndexing\` (le staging reste bloqué). Google-Extended pilote notamment l'usage AI Overviews / Gemini. → **fondation GEO**.
2. **Page comparative** — ajout d'un bloc **"Quick verdict / Le verdict en bref"** answer-first en haut (EN + FR), qui nomme le meilleur choix par usage avec des ancres internes. Optimisé pour les **featured snippets** et l'extraction par les **AI Overviews** sur les requêtes têtes.
3. **Guide \`plan-group-trip\`** — le lien "App Comparison" pointe désormais directement vers la page comparative (au lieu du hub \`/alternatives\`) avec une **ancre mot-clé**, transférant de l'autorité depuis une page forte vers la money page.

## Hors-scope (non codable)
Le saut position 9 → top 3 nécessite aussi du **off-page** : backlinks + citations directories/listicles (G2, Capterra, AlternativeTo, Reddit) — qui servent double : autorité **et** GEO.

## Vérifs
- ✅ `eslint` + `tsc` OK
- ✅ Rendu du bloc verdict vérifié **EN et FR** (screenshots)
- ✅ `/robots.txt` généré avec tous les bots IA + sitemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)