### PR TITLE
docs(seo): off-page execution pack (directory + outreach copy)

### DIFF
--- a/docs/seo/OFF_PAGE_EXECUTION.md
+++ b/docs/seo/OFF_PAGE_EXECUTION.md
@@ -1,0 +1,158 @@
+# Off-page execution pack — backlinks & authority
+
+> Converts `AUTHORITY_ROADMAP.md` (the plan) into copy-paste-ready actions.
+> Goal: move the money pages — first the comparative
+> `/alternatives/best-group-trip-planner-apps` (pos ~9.3, 26.9k impressions) —
+> from page-1-bottom into the top-5 by building domain authority + topically
+> relevant editorial links.
+> Created 2026-06-05. Status legend: ⬜ todo · 🟡 in progress · ✅ live.
+
+## State of play (2026-06-05)
+
+WePlanify appears on **zero** third-party directories (verified via search:
+AlternativeTo, G2, Capterra, SaaSHub, Product Hunt — only our own pages rank).
+On-page is mature; **domain authority is the sole bottleneck**. Off-page is
+greenfield, so the early wins are cheap and high-leverage.
+
+What needs a human (cannot be automated under the brand):
+- Account creation + email verification on each directory.
+- Founder identity / press contact where required.
+- Hitting "send" on outreach emails (drafts can be prepared).
+
+---
+
+## Canonical copy (reuse verbatim everywhere)
+
+- **Name:** WePlanify
+- **URL:** https://www.weplanify.com
+- **Tagline (≤60 ch):** The free group trip planner for friends
+- **One-liner (≤160 ch):** WePlanify is a free, collaborative group trip planner
+  with a shared day-by-day itinerary, group polls, a shared budget with automatic
+  settlement, and packing lists — built for trips with friends.
+- **Categories / tags:** Travel, Trip Planning, Productivity, Collaboration,
+  Group Travel, Itinerary, Travel App
+- **Pricing:** Free (premium tier planned; core stays free)
+- **Platforms:** Web, iOS, Android
+
+### 50-word description
+WePlanify is a free group trip planner built for friends. Plan a collaborative
+day-by-day itinerary together, run group polls to decide destinations and dates,
+track a shared budget with automatic settlement, and build packing lists — all in
+one app. Real-time collaboration, no paywall, available in English and French.
+
+### 200-word description
+Planning a group trip is chaos: endless WhatsApp threads, a messy spreadsheet for
+the budget, and no one agreeing on dates. WePlanify fixes that by putting
+everything groups actually need in one free app.
+
+Build a day-by-day itinerary together in real time — everyone can add activities,
+reorder days, and comment. Run group polls to settle destinations, dates, and
+restaurants without the back-and-forth. Track a shared budget that automatically
+calculates who owes whom, so nobody chases payments after the trip. Generate
+collaborative packing lists so nothing gets forgotten.
+
+Unlike solo-first tools such as Wanderlog or TripIt, WePlanify is built from the
+ground up for multiple people planning together. Unlike Splitwise, it does more
+than split costs — it handles the whole trip. And unlike most of the category,
+the core product is completely free with no per-trip limits.
+
+Available in English and French, on web, iOS, and Android. Whether it's a
+bachelorette weekend, a ski trip with friends, a family reunion, or a festival
+run, WePlanify keeps the whole crew on the same page — literally.
+
+---
+
+## Tier A — do first (highest relevance + authority)
+
+| # | Target | DR | Link | Status | Notes |
+|---|--------|----|----|--------|-------|
+| A1 | **AlternativeTo.net** | 70+ | dofollow | ⬜ | Niche-perfect. List as alternative to Wanderlog, TripIt, Splitwise, Stippl. Anchor relevance directly feeds the comparative page. |
+| A2 | **SaaSHub** | 50+ | dofollow | ⬜ | Submit + tag as alternative to the same competitors. Fast. |
+| A3 | **G2** | 90+ | dofollow | ⬜ | App is launched → now eligible. Claim profile, category: Travel Management / Trip Planning. |
+| A4 | **Capterra** | 90+ | dofollow | ⬜ | Same — eligible now. Free vendor listing. |
+| A5 | **Trustpilot** | 95+ | dofollow | ⬜ | Free business page; invite early users to review (ties activation → authority). |
+| A6 | **Product Hunt** | 90+ | dofollow | 🟡 | Listing exists but soft (2 upvotes). Ensure it links to weplanify.com; real amplification is a separate launch-day play. |
+
+**A1 AlternativeTo — submission specifics**
+- Type: Application · License: Free · Platforms: Web, iOS, Android
+- "Alternative to": Wanderlog, TripIt, Splitwise, Stippl, TravelSpend
+- Use the 50-word description + tagline above.
+
+## Tier B — easy dofollow volume (batch in one sitting)
+
+| Target | DR | Link | Status |
+|--------|----|----|--------|
+| BetaList | 60+ | dofollow | ⬜ |
+| StartupStash | 45+ | dofollow | ⬜ |
+| Launching Next | 40+ | dofollow | ⬜ |
+| SideProjectors | 30+ | dofollow | ⬜ |
+| MicroLaunch | 25+ | dofollow | ⬜ |
+| Uneed / ToolPilot | 30+ | dofollow | ⬜ |
+
+→ Same canonical copy. Budget ~10 min each (account + paste + submit).
+
+## Tier C — nofollow but traffic/trust signal
+
+| Target | Note | Status |
+|--------|------|--------|
+| Indie Hackers (profile + product) | Community + sameAs signal | ⬜ |
+| Hacker News (Show HN) | Nofollow, but referral traffic spike | ⬜ |
+| Reddit r/travel, r/grouptravel, r/bacheloretteparty | 80% value / 20% mention rule | ⬜ |
+
+---
+
+## Editorial outreach — "add us to your list" (highest-relevance links)
+
+These are the **most valuable links for ranking the comparative page**: same
+topic, same target queries. Existing "best group trip planner apps" listicles.
+Prepare as Gmail drafts; user reviews + sends. Find the author/editor email on
+the page's about/contact or via hunter.io before sending.
+
+**Targets** (re-verify the page is still live + still a list before pitching):
+1. joinmytrip.com/blog — group travel apps roundup
+2. howbout.app/blog — "five apps to make your group trips stress-free"
+3. travala.com/blog — "10 best travel planning apps"
+4. avosquado.app/blog — best group travel planning apps (competitor that lists rivals)
+5. infinitytransportation.net/blog — group travel planning apps
+6. engine.com/business-travel-guide — group travel planning
+
+### Outreach email (finalized — swap [Name]/[Article])
+```
+Subject: Quick suggestion for your "[Article title]" roundup
+
+Hi [Name],
+
+I came across your "[Article title]" piece while researching group-travel tools —
+genuinely useful list. One you might consider adding: WePlanify
+(https://www.weplanify.com).
+
+It's a free group trip planner built specifically for friend groups, with:
+- a collaborative day-by-day itinerary everyone edits in real time
+- group polls to settle dates and destinations
+- a shared budget with automatic "who owes whom" settlement
+- collaborative packing lists
+
+Unlike TripIt or Wanderlog (solo-first) or Splitwise (costs only), it covers the
+whole group trip in one place — and the core is completely free, no per-trip limits.
+
+Happy to send screenshots, a short blurb, or a logo if it's useful. Either way,
+thanks for the helpful article.
+
+Best,
+[Your name]
+WePlanify
+```
+
+---
+
+## Sequencing (2-week sprint)
+
+1. **Day 1–2:** Tier A (A1 AlternativeTo, A2 SaaSHub, A6 verify PH link). Biggest relevance.
+2. **Day 3–4:** A3 G2, A4 Capterra, A5 Trustpilot (claim + first review invites).
+3. **Day 5:** Tier B batch (6 directories, one sitting).
+4. **Week 2:** Outreach drafts → send 6 emails; Tier C community seeding.
+
+## Tracking
+- Re-check directory appearance via `site:domain weplanify` search weekly.
+- Watch the comparative page's GSC position (target 9.3 → top-5) over 4–8 weeks.
+- Ahrefs Webmaster Tools (free) for referring-domains count.


### PR DESCRIPTION
Ready-to-submit copy for the off-page authority push. Turns AUTHORITY_ROADMAP into copy-paste actions: canonical product copy, tiered directory list (AlternativeTo/SaaSHub/G2/Capterra first), finalized outreach emails. Internal docs only — no site/deploy impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)