### PR TITLE
chore(landing): social posts cache 1h → 10min

### DIFF
--- a/src/lib/instagram.ts
+++ b/src/lib/instagram.ts
@@ -68,13 +68,13 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.weplanify.com";
  *
  * The data is served by the Laravel API (administered in Filament), so the
  * marketing team can drop new images + captions without touching code. We
- * cache the response for an hour. When the API is unreachable or returns no
+ * cache the response for ten minutes. When the API is unreachable or returns no
  * posts, we fall back to MOCK_POSTS so the slider always renders.
  */
 export async function getInstagramPosts(limit = 8): Promise<InstagramPost[]> {
   try {
     const res = await fetch(`${API_URL}/api/social-posts`, {
-      next: { revalidate: 3600, tags: ["social-posts"] },
+      next: { revalidate: 600, tags: ["social-posts"] },
     });
     if (!res.ok) {
       return MOCK_POSTS.slice(0, limit);


### PR DESCRIPTION
## Quoi

Réduit le TTL du cache des social posts (slider Instagram) de **1h → 10min** dans `src/lib/instagram.ts`.

```ts
next: { revalidate: 600, tags: ["social-posts"] }
```

## Pourquoi

Les éditions de la marketing dans Filament (`/api/social-posts`) apparaissent plus vite sur la landing. Le tag `social-posts` reste dispo pour une invalidation immédiate à la demande.

🤖 Generated with [Claude Code](https://claude.com/claude-code)