### PR TITLE
fix(seo): consolidate indexation signals for GSC (WP-92)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,31 @@ const nextConfig: NextConfig = {
         destination: '/:locale/alternatives/best-group-trip-planner-apps',
         permanent: true,
       },
+      // WP-92: legacy article Google still requests (GSC 404). Same
+      // consolidation as WP-330. The bare (unprefixed) URL is the one Google
+      // indexed; it was a French article, hence the /fr destination.
+      {
+        source: '/:locale(en|fr)/blog/pourquoi-weplanify-est-plus-efficace',
+        destination: '/:locale/alternatives/best-group-trip-planner-apps',
+        permanent: true,
+      },
+      {
+        source: '/blog/pourquoi-weplanify-est-plus-efficace',
+        destination: '/fr/alternatives/best-group-trip-planner-apps',
+        permanent: true,
+      },
+      // WP-92: /features has no index page, so the middleware's locale
+      // redirect was landing on a 404. Features are showcased on the home.
+      {
+        source: '/:locale(en|es|fr|it|zh|de|pt|pl)/features',
+        destination: '/:locale',
+        permanent: true,
+      },
+      {
+        source: '/features',
+        destination: '/en',
+        permanent: true,
+      },
     ];
   },
   async headers() {

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import { PulsatingButton } from "@/components/magicui/pulsating-button";
+import { hreflangLanguages } from "@/lib/metadata";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -41,11 +42,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     twitter: { card: "summary_large_image", title, description },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME}`,
-        fr: `${SITE_URL}/fr${PATHNAME}`,
-        "x-default": `${SITE_URL}/en${PATHNAME}`,
-      },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/alternatives/best-group-trip-planner-apps/page.tsx
+++ b/src/app/[locale]/alternatives/best-group-trip-planner-apps/page.tsx
@@ -8,6 +8,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -90,11 +91,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME}`,
-        fr: `${SITE_URL}/fr${PATHNAME}`,
-        "x-default": `${SITE_URL}/en${PATHNAME}`,
-      },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/alternatives/cruzmi/page.tsx
+++ b/src/app/[locale]/alternatives/cruzmi/page.tsx
@@ -8,6 +8,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,11 +65,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${pathname}`,
-        fr: `${SITE_URL}/fr${pathname}`,
-        "x-default": `${SITE_URL}/en${pathname}`,
-      },
+      languages: hreflangLanguages(SITE_URL, "${pathname}"),
     },
   };
 }

--- a/src/app/[locale]/alternatives/page.tsx
+++ b/src/app/[locale]/alternatives/page.tsx
@@ -8,6 +8,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -68,11 +69,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${pathname}`,
-        fr: `${SITE_URL}/fr${pathname}`,
-        "x-default": `${SITE_URL}/en${pathname}`,
-      },
+      languages: hreflangLanguages(SITE_URL, "${pathname}"),
     },
   };
 }

--- a/src/app/[locale]/alternatives/squadtrip/page.tsx
+++ b/src/app/[locale]/alternatives/squadtrip/page.tsx
@@ -8,6 +8,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,11 +66,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${pathname}`,
-        fr: `${SITE_URL}/fr${pathname}`,
-        "x-default": `${SITE_URL}/en${pathname}`,
-      },
+      languages: hreflangLanguages(SITE_URL, "${pathname}"),
     },
   };
 }

--- a/src/app/[locale]/alternatives/stippl/page.tsx
+++ b/src/app/[locale]/alternatives/stippl/page.tsx
@@ -8,6 +8,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,11 +66,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${pathname}`,
-        fr: `${SITE_URL}/fr${pathname}`,
-        "x-default": `${SITE_URL}/en${pathname}`,
-      },
+      languages: hreflangLanguages(SITE_URL, "${pathname}"),
     },
   };
 }

--- a/src/app/[locale]/alternatives/tripit/page.tsx
+++ b/src/app/[locale]/alternatives/tripit/page.tsx
@@ -8,6 +8,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -60,11 +61,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${pathname}`,
-        fr: `${SITE_URL}/fr${pathname}`,
-        "x-default": `${SITE_URL}/en${pathname}`,
-      },
+      languages: hreflangLanguages(SITE_URL, "${pathname}"),
     },
   };
 }

--- a/src/app/[locale]/alternatives/wanderlog/page.tsx
+++ b/src/app/[locale]/alternatives/wanderlog/page.tsx
@@ -8,6 +8,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,11 +65,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${pathname}`,
-        fr: `${SITE_URL}/fr${pathname}`,
-        "x-default": `${SITE_URL}/en${pathname}`,
-      },
+      languages: hreflangLanguages(SITE_URL, "${pathname}"),
     },
   };
 }

--- a/src/app/[locale]/bachelorette-trip/page.tsx
+++ b/src/app/[locale]/bachelorette-trip/page.tsx
@@ -10,7 +10,7 @@ import Confetti from "@/components/Confetti";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
 
@@ -51,11 +51,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME}`,
-        fr: `${SITE_URL}/fr${PATHNAME}`,
-        "x-default": `${SITE_URL}/en${PATHNAME}`,
-      },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/birthday-trip/page.tsx
+++ b/src/app/[locale]/birthday-trip/page.tsx
@@ -10,7 +10,7 @@ import Confetti from "@/components/Confetti";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
 
@@ -51,11 +51,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME}`,
-        fr: `${SITE_URL}/fr${PATHNAME}`,
-        "x-default": `${SITE_URL}/en${PATHNAME}`,
-      },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/blog/group-trip-budget/page.tsx
+++ b/src/app/[locale]/blog/group-trip-budget/page.tsx
@@ -9,6 +9,7 @@ import { routing } from "@/i18n/routing";
 import { Metadata } from "next";
 import Breadcrumb from "@/components/Breadcrumb";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Static params
@@ -57,11 +58,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME_EN}`,
-        fr: `${SITE_URL}/fr${PATHNAME_FR}`,
-        "x-default": `${SITE_URL}/en${PATHNAME_EN}`,
-      },
+      languages: hreflangLanguages(SITE_URL, "${PATHNAME_EN}"),
     },
   };
 }

--- a/src/app/[locale]/blog/organiser-evjf/page.tsx
+++ b/src/app/[locale]/blog/organiser-evjf/page.tsx
@@ -9,6 +9,7 @@ import { routing } from "@/i18n/routing";
 import { Metadata } from "next";
 import Breadcrumb from "@/components/Breadcrumb";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Static params
@@ -56,11 +57,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME_EN}`,
-        fr: `${SITE_URL}/fr${PATHNAME_FR}`,
-        "x-default": `${SITE_URL}/en${PATHNAME_EN}`,
-      },
+      languages: hreflangLanguages(SITE_URL, "${PATHNAME_EN}"),
     },
   };
 }

--- a/src/app/[locale]/champions-league-final-2026-psg-arsenal/page.tsx
+++ b/src/app/[locale]/champions-league-final-2026-psg-arsenal/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: "Alex Martin" }],
     openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl },
     twitter: { ...metadata.twitter, title, description },
-    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+    alternates: { canonical: currentUrl, languages: hreflangLanguages(SITE_URL, PATHNAME) },
   };
 }
 

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -6,6 +6,7 @@ import { sanityFetch } from "@/sanity/lib/fetch";
 import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
 import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
 import { setRequestLocale, getTranslations } from 'next-intl/server';
+import { hreflangLanguages } from "@/lib/metadata";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -38,11 +39,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en/contact`,
-        fr: `${SITE_URL}/fr/contact`,
-        "x-default": `${SITE_URL}/en/contact`,
-      },
+      languages: hreflangLanguages(SITE_URL, "/contact"),
     },
   };
 }

--- a/src/app/[locale]/destinations/[slug]/page.tsx
+++ b/src/app/[locale]/destinations/[slug]/page.tsx
@@ -56,6 +56,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // Hreflang must point at each locale's own slug.
   const enUrl = `${SITE_URL}/en/destinations/${destination.slug.en}`;
   const frUrl = `${SITE_URL}/fr/destinations/${destination.slug.fr}`;
+  // Destination content only exists in en/fr; the other locales serve the en
+  // fallback, so they must canonicalize to the en URL instead of declaring
+  // themselves as independent (duplicate) pages (WP-92).
+  const canonicalUrl = locale === "en" || locale === "fr" ? currentUrl : enUrl;
 
   return {
     ...baseMetadata,
@@ -85,7 +89,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       images: [destination.hero.image],
     },
     alternates: {
-      canonical: currentUrl,
+      canonical: canonicalUrl,
       languages: {
         en: enUrl,
         fr: frUrl,

--- a/src/app/[locale]/destinations/page.tsx
+++ b/src/app/[locale]/destinations/page.tsx
@@ -13,7 +13,7 @@ import { sanityFetch } from "@/sanity/lib/fetch";
 import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
 import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
 
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import {
   destinations,
@@ -58,11 +58,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME}`,
-        fr: `${SITE_URL}/fr${PATHNAME}`,
-        "x-default": `${SITE_URL}/en${PATHNAME}`,
-      },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/events/page.tsx
+++ b/src/app/[locale]/events/page.tsx
@@ -8,7 +8,7 @@ import { PulsatingButton } from "@/components/magicui/pulsating-button";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 
 type Props = {
@@ -65,11 +65,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME}`,
-        fr: `${SITE_URL}/fr${PATHNAME}`,
-        "x-default": `${SITE_URL}/en${PATHNAME}`,
-      },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/family-trip/page.tsx
+++ b/src/app/[locale]/family-trip/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -42,7 +42,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     twitter: { ...metadata.twitter, title, description },
     alternates: {
       canonical: currentUrl,
-      languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/guides/plan-group-trip/page.tsx
+++ b/src/app/[locale]/guides/plan-group-trip/page.tsx
@@ -9,6 +9,7 @@ import { routing } from "@/i18n/routing";
 import { Metadata } from "next";
 import Breadcrumb from "@/components/Breadcrumb";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
+import { hreflangLanguages } from "@/lib/metadata";
 
 // ---------------------------------------------------------------------------
 // Static params
@@ -55,11 +56,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME}`,
-        fr: `${SITE_URL}/fr${PATHNAME}`,
-        "x-default": `${SITE_URL}/en${PATHNAME}`,
-      },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/hellfest-2026-trip-planner/page.tsx
+++ b/src/app/[locale]/hellfest-2026-trip-planner/page.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: "Alex Martin" }],
     openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl, images: [{ url: ogImage, width: 1456, height: 816, alt: title }] },
     twitter: { ...metadata.twitter, title, description, images: [ogImage] },
-    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+    alternates: { canonical: currentUrl, languages: hreflangLanguages(SITE_URL, PATHNAME) },
   };
 }
 

--- a/src/app/[locale]/partnership/page.tsx
+++ b/src/app/[locale]/partnership/page.tsx
@@ -6,6 +6,7 @@ import { sanityFetch } from "@/sanity/lib/fetch";
 import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
 import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { hreflangLanguages } from "@/lib/metadata";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -38,11 +39,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en/partnership`,
-        fr: `${SITE_URL}/fr/partnership`,
-        "x-default": `${SITE_URL}/en/partnership`,
-      },
+      languages: hreflangLanguages(SITE_URL, "/partnership"),
     },
   };
 }

--- a/src/app/[locale]/privacy-policy/page.tsx
+++ b/src/app/[locale]/privacy-policy/page.tsx
@@ -7,6 +7,7 @@ import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import Breadcrumb from "@/components/Breadcrumb";
+import { hreflangLanguages } from "@/lib/metadata";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -28,11 +29,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description: t("meta.description"),
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en/privacy-policy`,
-        fr: `${SITE_URL}/fr/privacy-policy`,
-        "x-default": `${SITE_URL}/en/privacy-policy`,
-      },
+      languages: hreflangLanguages(SITE_URL, "/privacy-policy"),
     },
   };
 }

--- a/src/app/[locale]/road-trip/page.tsx
+++ b/src/app/[locale]/road-trip/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: "Alex Martin" }],
     openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl },
     twitter: { ...metadata.twitter, title, description },
-    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+    alternates: { canonical: currentUrl, languages: hreflangLanguages(SITE_URL, PATHNAME) },
   };
 }
 

--- a/src/app/[locale]/school-trip/page.tsx
+++ b/src/app/[locale]/school-trip/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: "Alex Martin" }],
     openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl },
     twitter: { ...metadata.twitter, title, description },
-    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+    alternates: { canonical: currentUrl, languages: hreflangLanguages(SITE_URL, PATHNAME) },
   };
 }
 

--- a/src/app/[locale]/solar-eclipse-2026-trip-planner/page.tsx
+++ b/src/app/[locale]/solar-eclipse-2026-trip-planner/page.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: "Alex Martin" }],
     openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl, images: [{ url: ogImage, width: 1456, height: 816, alt: title }] },
     twitter: { ...metadata.twitter, title, description, images: [ogImage] },
-    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+    alternates: { canonical: currentUrl, languages: hreflangLanguages(SITE_URL, PATHNAME) },
   };
 }
 

--- a/src/app/[locale]/team-building/page.tsx
+++ b/src/app/[locale]/team-building/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: "Alex Martin" }],
     openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl },
     twitter: { ...metadata.twitter, title, description },
-    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+    alternates: { canonical: currentUrl, languages: hreflangLanguages(SITE_URL, PATHNAME) },
   };
 }
 

--- a/src/app/[locale]/tomorrowland-2026-trip-planner/page.tsx
+++ b/src/app/[locale]/tomorrowland-2026-trip-planner/page.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: "Alex Martin" }],
     openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl, images: [{ url: ogImage, width: 1456, height: 816, alt: title }] },
     twitter: { ...metadata.twitter, title, description, images: [ogImage] },
-    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+    alternates: { canonical: currentUrl, languages: hreflangLanguages(SITE_URL, PATHNAME) },
   };
 }
 

--- a/src/app/[locale]/travel-guides/[country]/page.tsx
+++ b/src/app/[locale]/travel-guides/[country]/page.tsx
@@ -54,6 +54,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const enUrl = `${SITE_URL}/en/travel-guides/${guide.slug.en}`;
   const frUrl = `${SITE_URL}/fr/travel-guides/${guide.slug.fr}`;
+  // Guide content only exists in en/fr; the other locales serve the en
+  // fallback, so they must canonicalize to the en URL instead of declaring
+  // themselves as independent (duplicate) pages (WP-92).
+  const canonicalUrl = locale === "en" || locale === "fr" ? currentUrl : enUrl;
 
   return {
     ...baseMetadata,
@@ -83,7 +87,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       images: [guide.hero.image],
     },
     alternates: {
-      canonical: currentUrl,
+      canonical: canonicalUrl,
       languages: {
         en: enUrl,
         fr: frUrl,

--- a/src/app/[locale]/travel-guides/page.tsx
+++ b/src/app/[locale]/travel-guides/page.tsx
@@ -13,7 +13,7 @@ import { sanityFetch } from "@/sanity/lib/fetch";
 import { navQuery, navigationQuery, footerQuery } from "@/sanity/lib/query";
 import { NavType, Navigation, Footer as FooterType } from "@/sanity/lib/type";
 
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import {
   countryGuides,
@@ -58,11 +58,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME}`,
-        fr: `${SITE_URL}/fr${PATHNAME}`,
-        "x-default": `${SITE_URL}/en${PATHNAME}`,
-      },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/trip-with-friends/page.tsx
+++ b/src/app/[locale]/trip-with-friends/page.tsx
@@ -9,7 +9,7 @@ import FloatingCards from "@/components/FloatingCards";
 import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
 
@@ -54,11 +54,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     alternates: {
       canonical: currentUrl,
-      languages: {
-        en: `${SITE_URL}/en${PATHNAME}`,
-        fr: `${SITE_URL}/fr${PATHNAME}`,
-        "x-default": `${SITE_URL}/en${PATHNAME}`,
-      },
+      languages: hreflangLanguages(SITE_URL, PATHNAME),
     },
   };
 }

--- a/src/app/[locale]/ultra-europe-2026-trip-planner/page.tsx
+++ b/src/app/[locale]/ultra-europe-2026-trip-planner/page.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: "Alex Martin" }],
     openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl, images: [{ url: ogImage, width: 1456, height: 816, alt: title }] },
     twitter: { ...metadata.twitter, title, description, images: [ogImage] },
-    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+    alternates: { canonical: currentUrl, languages: hreflangLanguages(SITE_URL, PATHNAME) },
   };
 }
 

--- a/src/app/[locale]/world-cup-2026-trip-planner/page.tsx
+++ b/src/app/[locale]/world-cup-2026-trip-planner/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleTOC from "@/components/ArticleTOC";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { generateMetadataFromSanity } from "@/lib/metadata";
+import { generateMetadataFromSanity, hreflangLanguages } from "@/lib/metadata";
 import { routing } from "@/i18n/routing";
 import FadeIn from "@/components/FadeIn";
 import { AuthorBio, AuthorJsonLd } from "@/components/AuthorBio";
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: "Alex Martin" }],
     openGraph: { ...metadata.openGraph, type: "article", title, description, url: currentUrl },
     twitter: { ...metadata.twitter, title, description },
-    alternates: { canonical: currentUrl, languages: { en: `${SITE_URL}/en${PATHNAME}`, fr: `${SITE_URL}/fr${PATHNAME}`, "x-default": `${SITE_URL}/en${PATHNAME}` } },
+    alternates: { canonical: currentUrl, languages: hreflangLanguages(SITE_URL, PATHNAME) },
   };
 }
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,10 +4,16 @@ import { seoSettingsQuery } from "@/sanity/lib/query";
 import { SeoSettings } from "@/sanity/lib/type";
 import { destinations } from "@/lib/destinations/data";
 import { countryGuides } from "@/lib/travel-guides/data";
-import { routing } from "@/i18n/routing";
+// WP-92: the sitemap only submits en/fr. The other 6 locales are served and
+// hreflang'd, but submitting all 8 (512 URLs) buried the en/fr pages Google
+// should crawl first (61 of them stuck in "Discovered - currently not
+// indexed"). Re-add a locale here once it has its own long-form content.
+const locales = ["en", "fr"] as const;
 
-// Derive sitemap locales from the routing config so adding a language is one place.
-const locales = routing.locales;
+// Stable fallback for pages without a real modification date. A `new Date()`
+// lastmod on every entry made the field meaningless to Google; bump this when
+// shipping a sweeping content change.
+const STATIC_LAST_MODIFIED = new Date("2026-06-11");
 const featureSlugs = [
   "planning",
   "budget",
@@ -39,7 +45,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     for (const locale of locales) {
       entries.push({
         url: `${siteUrl}/${locale}`,
-        lastModified: new Date(),
+        lastModified: STATIC_LAST_MODIFIED,
         changeFrequency: "weekly",
         priority: 1,
       });
@@ -51,7 +57,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       for (const page of useCasePages) {
         entries.push({
           url: `${siteUrl}/${locale}/${page}`,
-          lastModified: new Date(),
+          lastModified: STATIC_LAST_MODIFIED,
           changeFrequency: "monthly",
           priority: 0.9,
         });
@@ -68,7 +74,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       for (const page of guidePages) {
         entries.push({
           url: `${siteUrl}/${locale}/${page}`,
-          lastModified: new Date(),
+          lastModified: STATIC_LAST_MODIFIED,
           changeFrequency: "monthly",
           priority: 0.8,
         });
@@ -81,7 +87,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       for (const page of staticPages) {
         entries.push({
           url: `${siteUrl}/${locale}/${page}`,
-          lastModified: new Date(),
+          lastModified: STATIC_LAST_MODIFIED,
           changeFrequency: page === "blog" ? "weekly" : "monthly",
           priority: page === "blog" ? 0.8 : 0.7,
         });
@@ -93,7 +99,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       for (const slug of featureSlugs) {
         entries.push({
           url: `${siteUrl}/${locale}/features/${slug}`,
-          lastModified: new Date(),
+          lastModified: STATIC_LAST_MODIFIED,
           changeFrequency: "monthly",
           priority: 0.8,
         });
@@ -105,7 +111,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       for (const post of blogPosts) {
         entries.push({
           url: `${siteUrl}/${locale}/blog/${post.slug}`,
-          lastModified: post.publishedAt ? new Date(post.publishedAt) : new Date(),
+          lastModified: post.publishedAt ? new Date(post.publishedAt) : STATIC_LAST_MODIFIED,
           changeFrequency: "monthly",
           priority: 0.6,
         });
@@ -116,7 +122,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     for (const locale of locales) {
       entries.push({
         url: `${siteUrl}/${locale}/destinations`,
-        lastModified: new Date(),
+        lastModified: STATIC_LAST_MODIFIED,
         changeFrequency: "monthly",
         priority: 0.85,
       });
@@ -126,7 +132,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       for (const d of destinations) {
         entries.push({
           url: `${siteUrl}/${locale}/destinations/${d.slug[contentLocale]}`,
-          lastModified: new Date(),
+          lastModified: STATIC_LAST_MODIFIED,
           changeFrequency: "monthly",
           priority: 0.85,
         });
@@ -137,7 +143,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     for (const locale of locales) {
       entries.push({
         url: `${siteUrl}/${locale}/travel-guides`,
-        lastModified: new Date(),
+        lastModified: STATIC_LAST_MODIFIED,
         changeFrequency: "monthly",
         priority: 0.85,
       });
@@ -145,7 +151,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       for (const g of countryGuides) {
         entries.push({
           url: `${siteUrl}/${locale}/travel-guides/${g.slug[contentLocale]}`,
-          lastModified: new Date(),
+          lastModified: STATIC_LAST_MODIFIED,
           changeFrequency: "monthly",
           priority: 0.85,
         });
@@ -158,13 +164,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     return [
       {
         url: "https://www.weplanify.com/en",
-        lastModified: new Date(),
+        lastModified: STATIC_LAST_MODIFIED,
         changeFrequency: "weekly",
         priority: 1,
       },
       {
         url: "https://www.weplanify.com/fr",
-        lastModified: new Date(),
+        lastModified: STATIC_LAST_MODIFIED,
         changeFrequency: "weekly",
         priority: 1,
       },

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -19,7 +19,9 @@ const OG_LOCALES: Record<string, string> = {
 };
 
 // Builds the hreflang `languages` map for every supported locale + x-default (en).
-function hreflangLanguages(baseUrl: string, pathname: string): Record<string, string> {
+// Shared by every page so a page always lists itself in its own hreflang set
+// (WP-92: hand-rolled en/fr-only maps left /es, /it... out of their own set).
+export function hreflangLanguages(baseUrl: string, pathname: string): Record<string, string> {
   const languages: Record<string, string> = {};
   for (const locale of routing.locales) {
     languages[locale] = `${baseUrl}/${locale}${pathname}`;


### PR DESCRIPTION
## Contexte

Audit GSC du 11/06 : 67 pages indexées / 97 non indexées, sitemap de 512 URLs dont Google ne connaît que 164. 61 pages en/fr réelles bloquées en « Discovered – currently not indexed ».

Ticket : GuthHub WP-92

## Changements

- **Sitemap restreint à en/fr** (128 URLs au lieu de 512) : les 6 locales fallback noyaient les pages en/fr que Google doit crawler en priorité
- **`lastModified` stable** au lieu de `new Date()` à chaque génération (lastmod inexploitable par Google)
- **hreflang via le helper partagé `hreflangLanguages()`** sur les 30 pages qui hardcodaient en/fr/x-default : chaque locale servie figure désormais dans son propre set (avant, `/es/about` se self-canonicalisait sans apparaître dans son hreflang)
- **Canonical des locales fallback → version EN** sur destinations/[slug] et travel-guides/[country] (contenu en/fr only, les 6 autres locales servaient des doublons EN self-canonicalisés)
- **Redirects 308** : vieil article `/blog/pourquoi-weplanify-est-plus-efficace` (404 dans GSC) → listicle alternatives (même consolidation que WP-330) ; `/features` (redirigeait vers un 404) → home locale

## Vérifié en local (next build + next start)

- sitemap.xml : 128 `<loc>`, uniquement en/fr
- `/es/about` : canonical self + hreflang 8 locales incluant `es`
- `/es/destinations/tuscany-road-trip` : canonical → `/en/destinations/tuscany-road-trip`
- `/features`, `/en/features`, article legacy : 308 vers cibles 200

## Follow-ups hors repo (dans le ticket)

- Vercel : passer la redirection apex→www en 308 permanent
- `X-Robots-Tag: noindex` sur app.weplanify.com
- Resoumission sitemap + relance des validations GSC après MEP

🤖 Generated with [Claude Code](https://claude.com/claude-code)