### PR TITLE
fix(i18n): bundle message JSON into runtime (stop locale 500s / Googlebot)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -85,6 +85,14 @@ const nextConfig: NextConfig = {
   compress: true,
   poweredByHeader: false,
   generateEtags: false,
+  // i18n.ts loads message JSON at runtime via fs.readdirSync(process.cwd()/messages/<locale>).
+  // Next's static tracer can't follow that dynamic read, so the files were excluded from the
+  // serverless bundles -> messages resolved to {} at runtime -> MISSING_MESSAGE -> 500 (only on
+  // ISR/runtime renders, hence intermittent; build-time prerenders had the files on disk).
+  // Force the message files into every route bundle so the runtime fs read finds them.
+  outputFileTracingIncludes: {
+    "/**": ["./messages/**/*.json"],
+  },
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Symptôme
Des pages localisées renvoient un **500 intermittent** — invisible pour les vrais utilisateurs (cache/SSG → 200) mais **systématique pour Googlebot** et les rendus on-demand (ISR, locales hors paths prerendus). Détecté via GSC (URL inspection → "Server error 5xx") et confirmé dans les **logs runtime Vercel** : `Error: MISSING_MESSAGE: <namespace> (<locale>)`.

## Cause racine
`i18n.ts` charge les messages au runtime via `fs.readdirSync(process.cwd()/messages/<locale>)`. Le **file-tracer statique de Next ne peut pas suivre ce read dynamique** → les fichiers `messages/**` sont **exclus des bundles serverless/edge**. Au runtime `loadMessages()` renvoie `{}` → toutes les clés "manquent" → next-intl throw → 500.

Le build reste vert (fichiers présents sur disque au build → prerender OK), d'où l'aspect intermittent. Introduit par le refactor i18n par-fichier (#92).

**Le contenu n'a jamais manqué** : ex. `rootLayout.stickyCta` est bien dans le JSON, et pourtant la prod reporte `MISSING_MESSAGE: rootLayout`.

## Fix
`outputFileTracingIncludes` force `messages/**/*.json` dans chaque bundle de route. On garde le loader fs (pas de refactor).

## Vérification
- Build local : la trace `.next/server/app/[locale]/features/[slug]/page.js.nft.json` liste maintenant **544 fichiers de messages** (avant : 0). 47 routes référencent `messages/`.
- Build vert, aucune erreur i18n.
- Vérif réelle finale (UA Googlebot sur les pages ci-dessus) à faire sur la prod juste après merge — le preview est derrière Vercel Authentication.

## Impact
Débloque l'indexation des pages localisées (contributeur réel du backlog "Discovered, currently not indexed"). À déployer rapidement : Googlebot prend les 500 en continu.

> Note : un correctif de **résilience** complémentaire reste recommandé (ajouter `onError`/`getMessageFallback` dans `i18n.ts` pour qu'une clé manquante dégrade au lieu de 500) — séparé de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)