### PR TITLE
feat(hero): destination-search home hero variant (A/B prototype)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ NEXT_PUBLIC_GTM_ID=GTM-MJHJL7Q2
 # Required only when testing the OpenUI variant of the trip preview.
 OPENAI_API_KEY=
 OPENUI_TRIP_PREVIEW_MODEL=gpt-4o-mini
+
+# Home-hero A/B experiment. Off by default: ships search dark (reach via ?hero=search).
+# Set to true to start the 50/50 split.
+HERO_AB_ENABLED=false

--- a/next.config.ts
+++ b/next.config.ts
@@ -85,6 +85,13 @@ const nextConfig: NextConfig = {
   compress: true,
   poweredByHeader: false,
   generateEtags: false,
+  // next-intl loads the locale JSON via dynamic fs at request time, which Next's
+  // tracer can't follow — so dynamically-rendered pages (e.g. the cookie-bucketed
+  // home A/B) hit MISSING_MESSAGE on Vercel because the files aren't bundled.
+  // Force every route's serverless function to include the message catalogs.
+  outputFileTracingIncludes: {
+    '/**': ['./messages/**/*.json'],
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -7,6 +7,7 @@ import FadeIn from "@/components/FadeIn";
 import HeroPitchWall from "@/components/HeroPitchWall";
 import HeroSearch from "@/components/HeroSearch";
 import HeroVariantSwitcher from "@/components/HeroVariantSwitcher";
+import { cookies } from "next/headers";
 
 // Lazy-load below-the-fold components to reduce initial JS bundle
 const BigFeaturesSection = dynamic(() => import("@/components/BigFeaturesSection"));
@@ -37,9 +38,15 @@ export function generateStaticParams() {
 export default async function HomePage({ params, searchParams }: Props) {
   const { locale } = await params;
   const { hero: heroParam } = await searchParams;
-  // A/B hero variant: "search" = destination + dates entry (variant B).
-  // Default / "ai" = the current production AI-pitch hero (control, as on main).
-  const heroVariant: 'ai' | 'search' = heroParam === 'search' ? 'search' : 'ai';
+  // A/B hero variant. Precedence: explicit ?hero= (QA/dev override) > the cookie
+  // assigned 50/50 by middleware > "ai" (control). "search" = variant B.
+  const cookieVariant = (await cookies()).get('hero_variant')?.value;
+  const heroVariant: 'ai' | 'search' =
+    heroParam === 'search' || heroParam === 'ai'
+      ? heroParam
+      : cookieVariant === 'search'
+        ? 'search'
+        : 'ai';
   const isDev = process.env.NODE_ENV === 'development';
   setRequestLocale(locale);
   const t = await getTranslations("homePage");
@@ -84,10 +91,24 @@ export default async function HomePage({ params, searchParams }: Props) {
         navigationData={navigationData}
       />
 
+      {/* Publish the assigned A/B variant to the dataLayer before GTM tags fire,
+          so every event can be segmented by hero_variant. Inline (no client
+          component) to keep the chunk graph untouched. */}
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.dataLayer=window.dataLayer||[];window.dataLayer.push({hero_variant:${JSON.stringify(
+            heroVariant,
+          )}});window.dataLayer.push({event:'experiment_view',experiment:'home_hero',hero_variant:${JSON.stringify(
+            heroVariant,
+          )}});`,
+        }}
+      />
+
       {heroVariant === "search" ? (
         /* Variant B — destination + dates search hero. */
         <HeroSearch
           locale={locale}
+          variant={heroVariant}
           hero={{
             affiliateTag: t("hero.affiliateTag"),
             backgroundImage: HERO_BG,

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -5,6 +5,8 @@ import Nav from "@/components/Nav";
 import Footer from "@/components/Footer";
 import FadeIn from "@/components/FadeIn";
 import HeroPitchWall from "@/components/HeroPitchWall";
+import HeroSearch from "@/components/HeroSearch";
+import HeroVariantSwitcher from "@/components/HeroVariantSwitcher";
 
 // Lazy-load below-the-fold components to reduce initial JS bundle
 const BigFeaturesSection = dynamic(() => import("@/components/BigFeaturesSection"));
@@ -25,14 +27,20 @@ import { routing } from '@/i18n/routing';
 
 type Props = {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{ hero?: string }>;
 };
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
 
-export default async function HomePage({ params }: Props) {
+export default async function HomePage({ params, searchParams }: Props) {
   const { locale } = await params;
+  const { hero: heroParam } = await searchParams;
+  // A/B hero variant: "search" = destination + dates entry (variant B).
+  // Default / "ai" = the current production AI-pitch hero (control, as on main).
+  const heroVariant: 'ai' | 'search' = heroParam === 'search' ? 'search' : 'ai';
+  const isDev = process.env.NODE_ENV === 'development';
   setRequestLocale(locale);
   const t = await getTranslations("homePage");
   // Homepage copy (hero, world section, and every section component) now comes
@@ -76,15 +84,30 @@ export default async function HomePage({ params }: Props) {
         navigationData={navigationData}
       />
 
-      <HeroPitchWall
-        locale={locale}
-        hero={{
-          affiliateTag: t("hero.affiliateTag"),
-          title: t("hero.title"),
-          description: t("hero.description"),
-          backgroundImage: HERO_BG,
-        }}
-      />
+      {heroVariant === "search" ? (
+        /* Variant B — destination + dates search hero. */
+        <HeroSearch
+          locale={locale}
+          hero={{
+            affiliateTag: t("hero.affiliateTag"),
+            backgroundImage: HERO_BG,
+          }}
+        />
+      ) : (
+        /* Control — production AI-pitch hero (as on main). */
+        <HeroPitchWall
+          locale={locale}
+          hero={{
+            affiliateTag: t("hero.affiliateTag"),
+            title: t("hero.title"),
+            description: t("hero.description"),
+            backgroundImage: HERO_BG,
+          }}
+        />
+      )}
+
+      {/* DEV-only A/B variant switcher (never rendered in production). */}
+      {isDev && <HeroVariantSwitcher current={heroVariant} />}
 
       {/* Testimonial & Stats Section */}
       <section id="reviews" className="px-4 lg:px-8 pb-8 lg:pb-12">

--- a/src/components/HeroSearch.tsx
+++ b/src/components/HeroSearch.tsx
@@ -28,6 +28,7 @@ interface HeroData {
 interface Props {
   hero: HeroData;
   locale: string;
+  variant: 'ai' | 'search';
 }
 
 interface Suggestion {
@@ -86,7 +87,7 @@ const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDat
 const toISO = (d: Date) =>
   `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 
-export default function HeroSearch({ hero, locale }: Props) {
+export default function HeroSearch({ hero, locale, variant }: Props) {
   const lang = locale === 'fr' ? 'fr' : 'en';
   const t = COPY[lang];
   const intlLocale = lang === 'fr' ? 'fr-FR' : 'en-US';
@@ -270,13 +271,13 @@ export default function HeroSearch({ hero, locale }: Props) {
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const token = (await res.json())?.token as string | undefined;
-      const params = new URLSearchParams({ utm_source: 'hero_search' });
+      const params = new URLSearchParams({ utm_source: 'hero_search', hero_variant: variant });
       if (token) params.set('pitch', token);
       window.location.href = `${APP_URL}/register?${params.toString()}`;
     } catch {
       // Never leave the click as a dead end: if the preview API is unreachable,
       // fall back to register with the raw destinations as query params.
-      const params = new URLSearchParams({ utm_source: 'hero_search' });
+      const params = new URLSearchParams({ utm_source: 'hero_search', hero_variant: variant });
       stops.forEach((s) => params.append('destination', s.name));
       if (startISO) params.set('start', startISO);
       if (endISO) params.set('end', endISO);

--- a/src/components/HeroSearch.tsx
+++ b/src/components/HeroSearch.tsx
@@ -1,0 +1,561 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ArrowRight,
+  MapPin,
+  CalendarDays,
+  Search,
+  Loader2,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  X,
+} from 'lucide-react';
+import { trackEvent } from '@/lib/tracking';
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.weplanify.com';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.weplanify.com';
+const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN || '';
+
+interface HeroData {
+  affiliateTag?: string | null;
+  backgroundImage?: string | null;
+}
+
+interface Props {
+  hero: HeroData;
+  locale: string;
+}
+
+interface Suggestion {
+  id: string;
+  name: string;
+  context: string;
+  latitude: number | null;
+  longitude: number | null;
+  country: string | null;
+  countryCode: string | null;
+}
+
+interface MapboxFeature {
+  id: string;
+  text: string;
+  place_name: string;
+  center?: [number, number];
+  properties?: { short_code?: string };
+  context?: { id: string; text: string; short_code?: string }[];
+}
+
+// Self-contained copy so this experimental variant doesn't require touching the
+// 8 localized message files. Falls back to English for any non-FR locale.
+const COPY = {
+  en: {
+    affiliate: 'Plan your group trip, together.',
+    title: 'Where to next?',
+    subtitle: 'Pick a destination and your dates — we build the shared plan your whole group can edit.',
+    destinationLabel: 'Destination',
+    destinationPlaceholder: 'Search a city or country',
+    addStopPlaceholder: 'Add another stop',
+    fromLabel: 'From',
+    toLabel: 'To',
+    addDate: 'Add date',
+    cta: 'Start planning',
+    note: 'Join 300+ travelers planning their next trip',
+    weekdays: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
+  },
+  fr: {
+    affiliate: 'Planifiez votre voyage de groupe, ensemble.',
+    title: 'On part où ?',
+    subtitle: 'Choisis une destination et tes dates — on construit le plan partagé que tout le groupe peut éditer.',
+    destinationLabel: 'Destination',
+    destinationPlaceholder: 'Cherche une ville ou un pays',
+    addStopPlaceholder: 'Ajouter une étape',
+    fromLabel: 'Départ',
+    toLabel: 'Retour',
+    addDate: 'Ajouter',
+    cta: 'Commencer',
+    note: 'Rejoins 300+ voyageurs qui préparent leur prochain voyage',
+    weekdays: ['Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa', 'Di'],
+  },
+} as const;
+
+const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+const toISO = (d: Date) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+
+export default function HeroSearch({ hero, locale }: Props) {
+  const lang = locale === 'fr' ? 'fr' : 'en';
+  const t = COPY[lang];
+  const intlLocale = lang === 'fr' ? 'fr-FR' : 'en-US';
+
+  // --- Destinations (multi-stop / road trip) ---
+  const [query, setQuery] = useState('');
+  const [destinations, setDestinations] = useState<Suggestion[]>([]);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [destOpen, setDestOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const destRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // --- Date range ---
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const [start, setStart] = useState<Date | null>(null);
+  const [end, setEnd] = useState<Date | null>(null);
+  const [dateOpen, setDateOpen] = useState(false);
+  const [dateFocus, setDateFocus] = useState<'start' | 'end'>('start');
+  const [viewMonth, setViewMonth] = useState<Date>(() => new Date(today.getFullYear(), today.getMonth(), 1));
+  const dateRef = useRef<HTMLDivElement>(null);
+
+  function openDates(focus: 'start' | 'end') {
+    setDateFocus(focus === 'end' && !start ? 'start' : focus);
+    setDateOpen(true);
+  }
+
+  // Close popovers on outside click.
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (destRef.current && !destRef.current.contains(e.target as Node)) setDestOpen(false);
+      if (dateRef.current && !dateRef.current.contains(e.target as Node)) setDateOpen(false);
+    }
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, []);
+
+  // Debounced Mapbox geocoding autocomplete.
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2 || !MAPBOX_TOKEN) {
+      setSuggestions([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    const handle = setTimeout(async () => {
+      try {
+        const url =
+          `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json` +
+          `?types=place,region,country&limit=5&language=${lang}&access_token=${MAPBOX_TOKEN}`;
+        const res = await fetch(url);
+        const data = await res.json();
+        if (cancelled) return;
+        const items: Suggestion[] = (data.features || []).map((f: MapboxFeature) => {
+          // For a country result the feature itself carries the code; for a
+          // city/region it's in the `country.*` context entry.
+          const countryCtx = f.id.startsWith('country.')
+            ? { text: f.text, short_code: f.properties?.short_code }
+            : f.context?.find((c) => c.id.startsWith('country.'));
+          return {
+            id: f.id,
+            name: f.text,
+            context: f.place_name,
+            latitude: Array.isArray(f.center) ? f.center[1] : null,
+            longitude: Array.isArray(f.center) ? f.center[0] : null,
+            country: countryCtx?.text ?? null,
+            countryCode: countryCtx?.short_code ? countryCtx.short_code.toUpperCase() : null,
+          };
+        });
+        setSuggestions(items);
+        setDestOpen(items.length > 0);
+      } catch {
+        if (!cancelled) setSuggestions([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, lang]);
+
+  // Add a destination as a chip (supports multi-stop road trips), then reset
+  // the input so the user can keep adding stops.
+  function addPlace(s: Suggestion) {
+    setDestinations((prev) => (prev.some((p) => p.id === s.id) ? prev : [...prev, s]));
+    setQuery('');
+    setSuggestions([]);
+    setDestOpen(false);
+    inputRef.current?.focus();
+  }
+
+  function removePlace(id: string) {
+    setDestinations((prev) => prev.filter((p) => p.id !== id));
+  }
+
+  // Calendar grid for the displayed month (week starts Monday).
+  const grid = useMemo(() => {
+    const year = viewMonth.getFullYear();
+    const month = viewMonth.getMonth();
+    const firstWeekday = (new Date(year, month, 1).getDay() + 6) % 7; // Mon=0
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const cells: (Date | null)[] = [];
+    for (let i = 0; i < firstWeekday; i++) cells.push(null);
+    for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d));
+    return cells;
+  }, [viewMonth]);
+
+  // Calendar navigation — never let the view land before the current month.
+  const monthFloor = new Date(today.getFullYear(), today.getMonth(), 1);
+  const atFloor = viewMonth.getTime() === monthFloor.getTime();
+  function shiftView(months: number) {
+    setViewMonth((m) => {
+      const next = new Date(m.getFullYear(), m.getMonth() + months, 1);
+      return next < monthFloor ? monthFloor : next;
+    });
+  }
+
+  function pickDay(d: Date) {
+    if (dateFocus === 'start') {
+      setStart(d);
+      if (end && d >= end) setEnd(null);
+      setDateFocus('end');
+    } else if (!start || d < start) {
+      // Picking an "end" earlier than start re-anchors the start instead.
+      setStart(d);
+      setEnd(null);
+      setDateFocus('end');
+    } else {
+      setEnd(d);
+      setDateFocus('start');
+      setDateOpen(false);
+    }
+  }
+
+  const fmt = (d: Date) => d.toLocaleDateString(intlLocale, { day: 'numeric', month: 'short' });
+
+  const inRange = (d: Date) => Boolean(start && end && d >= start && d <= end);
+  const isEdge = (d: Date) =>
+    Boolean((start && d.getTime() === start.getTime()) || (end && d.getTime() === end.getTime()));
+
+  async function submit() {
+    if (submitting) return;
+
+    // Confirmed chips, plus any free text still in the input that wasn't added.
+    const stops = destinations.map((d) => ({
+      name: d.name,
+      latitude: d.latitude,
+      longitude: d.longitude,
+      country: d.country,
+      country_code: d.countryCode,
+    }));
+    const trailing = query.trim();
+    if (trailing && !stops.some((s) => s.name === trailing)) {
+      stops.push({ name: trailing, latitude: null, longitude: null, country: null, country_code: null });
+    }
+    if (stops.length === 0) {
+      inputRef.current?.focus();
+      return;
+    }
+
+    trackEvent('hero_search_submit', {
+      destination: stops.map((s) => s.name).join(' → '),
+      stops: stops.length,
+      hasDates: Boolean(start && end),
+      locale: lang,
+    });
+
+    const startISO = start ? toISO(start) : null;
+    const endISO = end ? toISO(end) : null;
+    setSubmitting(true);
+
+    try {
+      const res = await fetch(`${API_URL}/api/public/trip-preview/from-search`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ destinations: stops, start: startISO, end: endISO, locale: lang }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const token = (await res.json())?.token as string | undefined;
+      const params = new URLSearchParams({ utm_source: 'hero_search' });
+      if (token) params.set('pitch', token);
+      window.location.href = `${APP_URL}/register?${params.toString()}`;
+    } catch {
+      // Never leave the click as a dead end: if the preview API is unreachable,
+      // fall back to register with the raw destinations as query params.
+      const params = new URLSearchParams({ utm_source: 'hero_search' });
+      stops.forEach((s) => params.append('destination', s.name));
+      if (startISO) params.set('start', startISO);
+      if (endISO) params.set('end', endISO);
+      window.location.href = `${APP_URL}/register?${params.toString()}`;
+    }
+  }
+
+  return (
+    <div id="hero" className="pt-[100px] lg:pt-[120px] px-4 lg:px-8 pb-4 lg:pb-6">
+      <div className="max-w-[1536px] mx-auto">
+        {/* No overflow-hidden here: the date/destination popovers must escape the
+            hero bounds. The rounded image is clipped by its own layer below. */}
+        <section className="relative rounded-[24px] lg:rounded-[40px]">
+          <div className="absolute inset-0 z-0 overflow-hidden rounded-[24px] lg:rounded-[40px]">
+            <Image
+              src="/header-bg-mobile.webp"
+              alt={t.title}
+              fill
+              sizes="100vw"
+              className="object-cover lg:hidden"
+              priority
+              fetchPriority="high"
+            />
+            <Image
+              src={hero.backgroundImage || '/header-bg.webp'}
+              alt={t.title}
+              fill
+              sizes="100vw"
+              className="object-cover hidden lg:block"
+              priority
+              fetchPriority="high"
+            />
+            <div className="absolute inset-0 bg-black/45" />
+          </div>
+
+          <div className="relative z-10 w-full min-h-[480px] lg:min-h-[600px] flex flex-col items-center justify-center text-center px-4 lg:px-8 py-12 lg:py-16">
+            <div className="font-nanum-pen text-[#EEF899] text-xl lg:text-2xl mb-3 drop-shadow-[0_1px_8px_rgba(0,0,0,0.4)]">
+              {t.affiliate}
+            </div>
+            <h1 className="text-[#FFFBF5] text-4xl lg:text-6xl xl:text-[64px] font-londrina-solid leading-[1.05] max-w-4xl mb-4 drop-shadow-[0_2px_20px_rgba(0,0,0,0.35)]">
+              {t.title}
+            </h1>
+            <p className="text-[#FFFBF5]/90 font-karla text-base lg:text-lg leading-relaxed max-w-2xl mb-8 drop-shadow-[0_1px_8px_rgba(0,0,0,0.4)]">
+              {t.subtitle}
+            </p>
+
+            {/* Search card */}
+            <div className="w-full max-w-4xl bg-[#FFFBF5] rounded-3xl lg:rounded-full shadow-2xl p-2 flex flex-col lg:flex-row items-stretch gap-1">
+              {/* Destination */}
+              <div ref={destRef} className="relative flex-[1.3] min-w-0">
+                <div className="flex items-center gap-3 px-5 py-3 rounded-2xl lg:rounded-full hover:bg-black/[0.03] transition-colors h-full">
+                  <MapPin className="w-5 h-5 text-orange shrink-0" />
+                  <div className="flex flex-col items-start text-left w-full min-w-0">
+                    <span className="text-[10px] font-karla font-bold uppercase tracking-[0.12em] text-[#001E13]/45">
+                      {t.destinationLabel}
+                    </span>
+                    <input
+                      ref={inputRef}
+                      type="text"
+                      value={query}
+                      onChange={(e) => setQuery(e.target.value)}
+                      onFocus={() => suggestions.length > 0 && setDestOpen(true)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && suggestions[0]) {
+                          e.preventDefault();
+                          addPlace(suggestions[0]);
+                        }
+                      }}
+                      placeholder={destinations.length ? t.addStopPlaceholder : t.destinationPlaceholder}
+                      className="w-full bg-transparent outline-none font-karla font-semibold text-[#001E13] placeholder:font-normal placeholder:text-[#001E13]/40 text-sm lg:text-base truncate"
+                    />
+                  </div>
+                  {loading && <Loader2 className="w-4 h-4 text-[#001E13]/40 animate-spin shrink-0" />}
+                </div>
+
+                {destOpen && suggestions.length > 0 && (
+                  <ul className="absolute z-50 left-0 bottom-full mb-3 w-[min(360px,90vw)] bg-white rounded-2xl shadow-[0_12px_40px_rgba(0,0,0,0.18)] border border-black/5 overflow-hidden text-left py-1.5">
+                    {suggestions.map((s) => (
+                      <li key={s.id}>
+                        <button
+                          type="button"
+                          onClick={() => addPlace(s)}
+                          className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-[#EEF899]/30 transition-colors"
+                        >
+                          <MapPin className="w-4 h-4 text-orange shrink-0" />
+                          <span className="flex flex-col items-start min-w-0 text-left">
+                            <span className="font-karla font-bold text-sm text-[#001E13] truncate max-w-full">
+                              {s.name}
+                            </span>
+                            <span className="font-karla text-xs text-[#001E13]/50 truncate max-w-full">
+                              {s.context}
+                            </span>
+                          </span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="hidden lg:block w-px bg-black/10 my-2.5" />
+
+              {/* Dates — explicit From / To so the range reads at a glance. */}
+              <div ref={dateRef} className="relative flex-[1.4] min-w-0 flex items-stretch">
+                {/* From */}
+                <button
+                  type="button"
+                  onClick={() => openDates('start')}
+                  className={`flex-1 min-w-0 flex items-center gap-2.5 px-5 py-3 rounded-2xl lg:rounded-full transition-colors text-left ${
+                    dateOpen && dateFocus === 'start' ? 'bg-black/[0.05]' : 'hover:bg-black/[0.03]'
+                  }`}
+                >
+                  <CalendarDays className="w-5 h-5 text-orange shrink-0" />
+                  <span className="flex flex-col items-start min-w-0">
+                    <span className="text-[10px] font-karla font-bold uppercase tracking-[0.12em] text-[#001E13]/45">
+                      {t.fromLabel}
+                    </span>
+                    <span
+                      className={`font-karla text-sm lg:text-base truncate ${
+                        start ? 'font-semibold text-[#001E13]' : 'text-[#001E13]/40'
+                      }`}
+                    >
+                      {start ? fmt(start) : t.addDate}
+                    </span>
+                  </span>
+                </button>
+
+                <div className="w-px bg-black/10 my-2.5" />
+
+                {/* To */}
+                <button
+                  type="button"
+                  onClick={() => openDates('end')}
+                  className={`flex-1 min-w-0 flex items-center gap-2.5 px-5 py-3 rounded-2xl lg:rounded-full transition-colors text-left ${
+                    dateOpen && dateFocus === 'end' ? 'bg-black/[0.05]' : 'hover:bg-black/[0.03]'
+                  }`}
+                >
+                  <span className="flex flex-col items-start min-w-0">
+                    <span className="text-[10px] font-karla font-bold uppercase tracking-[0.12em] text-[#001E13]/45">
+                      {t.toLabel}
+                    </span>
+                    <span
+                      className={`font-karla text-sm lg:text-base truncate ${
+                        end ? 'font-semibold text-[#001E13]' : 'text-[#001E13]/40'
+                      }`}
+                    >
+                      {end ? fmt(end) : t.addDate}
+                    </span>
+                  </span>
+                </button>
+
+                {dateOpen && (
+                  <div className="absolute z-50 left-0 lg:left-auto lg:right-0 bottom-full mb-3 w-[320px] max-w-[90vw] bg-white rounded-2xl shadow-[0_12px_40px_rgba(0,0,0,0.18)] border border-black/5 p-4">
+                    <div className="flex items-center justify-between mb-3">
+                      <div className="flex items-center gap-0.5">
+                        <button
+                          type="button"
+                          aria-label="Previous year"
+                          onClick={() => shiftView(-12)}
+                          disabled={atFloor}
+                          className="p-1.5 rounded-full hover:bg-black/5 disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          <ChevronsLeft className="w-4 h-4 text-[#001E13]" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Previous month"
+                          onClick={() => shiftView(-1)}
+                          disabled={atFloor}
+                          className="p-1.5 rounded-full hover:bg-black/5 disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          <ChevronLeft className="w-4 h-4 text-[#001E13]" />
+                        </button>
+                      </div>
+                      <span className="font-karla font-bold text-sm text-[#001E13] capitalize">
+                        {viewMonth.toLocaleDateString(intlLocale, { month: 'long', year: 'numeric' })}
+                      </span>
+                      <div className="flex items-center gap-0.5">
+                        <button
+                          type="button"
+                          aria-label="Next month"
+                          onClick={() => shiftView(1)}
+                          className="p-1.5 rounded-full hover:bg-black/5"
+                        >
+                          <ChevronRight className="w-4 h-4 text-[#001E13]" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Next year"
+                          onClick={() => shiftView(12)}
+                          className="p-1.5 rounded-full hover:bg-black/5"
+                        >
+                          <ChevronsRight className="w-4 h-4 text-[#001E13]" />
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-7 gap-y-1 mb-1">
+                      {t.weekdays.map((w) => (
+                        <span key={w} className="text-center text-[11px] font-karla font-bold text-[#001E13]/40">
+                          {w}
+                        </span>
+                      ))}
+                    </div>
+
+                    <div className="grid grid-cols-7 gap-y-1">
+                      {grid.map((d, i) => {
+                        if (!d) return <span key={`b${i}`} />;
+                        const past = d < today;
+                        const edge = isEdge(d);
+                        const range = inRange(d) && !edge;
+                        return (
+                          <button
+                            key={toISO(d)}
+                            type="button"
+                            disabled={past}
+                            onClick={() => pickDay(d)}
+                            className={[
+                              'h-9 w-9 mx-auto flex items-center justify-center text-sm font-karla rounded-full transition-colors',
+                              past ? 'text-[#001E13]/25 cursor-not-allowed' : 'text-[#001E13] hover:bg-[#EEF899]/50',
+                              edge ? 'bg-orange text-white hover:bg-orange font-bold' : '',
+                              range ? 'bg-[#EEF899]/60 rounded-none' : '',
+                            ].join(' ')}
+                          >
+                            {d.getDate()}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* CTA */}
+              <button
+                type="button"
+                onClick={submit}
+                disabled={submitting}
+                className="inline-flex items-center justify-center gap-2 px-7 py-4 rounded-2xl lg:rounded-full bg-orange hover:bg-orange/90 disabled:opacity-70 disabled:cursor-wait text-white font-karla font-bold text-base lg:text-lg transition-colors shrink-0"
+              >
+                {submitting ? (
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                ) : (
+                  <>
+                    <Search className="w-4 h-4 lg:hidden" />
+                    {t.cta}
+                    <ArrowRight className="w-4 h-4 hidden lg:block" />
+                  </>
+                )}
+              </button>
+            </div>
+
+            {/* Selected stops — multiple = road trip. */}
+            {destinations.length > 0 && (
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+                {destinations.map((d, i) => (
+                  <span
+                    key={d.id}
+                    className="inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1.5 rounded-full bg-[#FFFBF5] text-[#001E13] font-karla font-semibold text-sm shadow-lg"
+                  >
+                    <span className="text-orange font-bold">{i + 1}</span>
+                    {d.name}
+                    <button
+                      type="button"
+                      onClick={() => removePlace(d.id)}
+                      aria-label={`Remove ${d.name}`}
+                      className="rounded-full hover:bg-black/10 p-0.5 transition-colors"
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <p className="mt-4 font-nanum-pen text-[#FFFBF5]/75 text-base lg:text-lg">{t.note}</p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HeroVariantSwitcher.tsx
+++ b/src/components/HeroVariantSwitcher.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Sparkles, Search } from 'lucide-react';
+
+/**
+ * DEV-ONLY floating control to preview the two home hero variants locally.
+ * Renders nothing in production builds. Variant is driven by the `?hero=`
+ * query param and read server-side in the page — this only flips the param.
+ */
+export default function HeroVariantSwitcher({ current }: { current: 'ai' | 'search' }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+
+  function go(variant: 'ai' | 'search') {
+    const next = new URLSearchParams(params.toString());
+    next.set('hero', variant);
+    router.push(`${pathname}?${next.toString()}`);
+  }
+
+  const base =
+    'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-bold transition-colors';
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[9999] flex items-center gap-1 rounded-full bg-[#001E13] p-1 shadow-2xl ring-1 ring-white/10">
+      <span className="px-2 text-[10px] font-bold uppercase tracking-wider text-white/40">A/B</span>
+      <button
+        type="button"
+        onClick={() => go('ai')}
+        className={`${base} ${current === 'ai' ? 'bg-[#EEF899] text-[#001E13]' : 'text-white/70 hover:text-white'}`}
+      >
+        <Sparkles className="h-3.5 w-3.5" /> AI flow
+      </button>
+      <button
+        type="button"
+        onClick={() => go('search')}
+        className={`${base} ${current === 'search' ? 'bg-[#EEF899] text-[#001E13]' : 'text-white/70 hover:text-white'}`}
+      >
+        <Search className="h-3.5 w-3.5" /> Search
+      </button>
+    </div>
+  );
+}

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -27,6 +27,10 @@ export type EventCatalog = {
   hero_pitch_success: { destination: string };
   hero_pitch_cta_click: { destination: string };
 
+  // Search hero (A/B variant B) — destination(s) + dates entry point.
+  // `stops` > 1 means a multi-destination road trip.
+  hero_search_submit: { destination: string; stops: number; hasDates: boolean; locale: string };
+
   // Pitch flow — inline (in-page sections)
   inline_pitch_submit: { location: string; length: number; locale: string };
   inline_pitch_success: { location: string; destination: string };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,43 @@ import { routing } from './i18n/routing';
 
 const intlMiddleware = createMiddleware(routing);
 
+const HERO_VARIANT_COOKIE = 'hero_variant';
+const HERO_VARIANTS = ['ai', 'search'] as const;
+const HERO_COOKIE_OPTS = { path: '/', maxAge: 60 * 60 * 24 * 180, sameSite: 'lax' as const };
+
+// Off by default: the first deploy ships the search variant dark — everyone
+// stays on the control (AI) and only `?hero=search` reaches it. Flip to "true"
+// to start enrolling real visitors in the 50/50 experiment.
+const HERO_AB_ENABLED = process.env.HERO_AB_ENABLED === 'true';
+
+/**
+ * Resolve the home-hero A/B variant for this request and persist it in a cookie.
+ *
+ * - `?hero=ai|search` is an explicit override (QA / dark-launch testing) and is
+ *   made sticky so the chosen variant survives navigation across the funnel.
+ * - Otherwise, only when the experiment is enabled do we enroll the visitor in a
+ *   stable 50/50 bucket. While disabled, no cookie is set → the page defaults to
+ *   the control.
+ */
+function assignHeroVariant(request: NextRequest, response: NextResponse): NextResponse {
+  const override = request.nextUrl.searchParams.get('hero');
+  if (override === 'ai' || override === 'search') {
+    response.cookies.set(HERO_VARIANT_COOKIE, override, HERO_COOKIE_OPTS);
+    return response;
+  }
+
+  if (!HERO_AB_ENABLED) {
+    return response;
+  }
+
+  const current = request.cookies.get(HERO_VARIANT_COOKIE)?.value;
+  if (!HERO_VARIANTS.includes(current as (typeof HERO_VARIANTS)[number])) {
+    const assigned = Math.random() < 0.5 ? 'ai' : 'search';
+    response.cookies.set(HERO_VARIANT_COOKIE, assigned, HERO_COOKIE_OPTS);
+  }
+  return response;
+}
+
 function pickLocaleFromAcceptLanguage(header: string | null): string {
   if (!header) return routing.defaultLocale;
   const tags = header
@@ -32,10 +69,10 @@ export default function middleware(request: NextRequest) {
     // Vary on Accept-Language so each locale gets a fair shot at being the
     // canonical for its language instead of one being a permanent redirect target.
     response.headers.set('Vary', 'Accept-Language');
-    return response;
+    return assignHeroVariant(request, response);
   }
 
-  return intlMiddleware(request);
+  return assignHeroVariant(request, intlMiddleware(request));
 }
 
 export const config = {


### PR DESCRIPTION
Variant **B** of the home hero: a Wanderlog-style destination search instead of the AI pitch flow.

## What
- `HeroSearch`: multi-stop destination autocomplete (Mapbox) + date-range picker. Multiple stops ⇒ road trip.
- On submit: POST `trip-preview/from-search` → redirect to `register?pitch=token` (graceful fallback to raw params if the API is down).
- Dev-only variant switcher driven by `?hero=` (control = AI flow).

## ⚠️ Prototype — not yet shippable as a live test
- The real **50/50 split (cookie + middleware) and per-variant telemetry are a follow-up** — without them we can't declare a winner.
- `?hero=` makes the home dynamically rendered (SEO concern).
- Hero copy is inline EN/FR pending move to `messages/`.
- Autocomplete is Mapbox; Google (app parity) was the agreed target.

## Depends on
`weplanify-backend#427` (the `from-search` endpoint) deployed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
