### PR TITLE
feat(observability): Sentry error monitoring on the landing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ NEXT_PUBLIC_GTM_ID=GTM-MJHJL7Q2
 # Required only when testing the OpenUI variant of the trip preview.
 OPENAI_API_KEY=
 OPENUI_TRIP_PREVIEW_MODEL=gpt-4o-mini
+
+# Sentry (error monitoring). Leave unset to disable (no-op).
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_AUTH_TOKEN=
+NEXT_PUBLIC_SENTRY_RELEASE=

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,20 @@
+import * as Sentry from '@sentry/nextjs';
+
+// Browser Sentry init (App Router). No-ops without a DSN.
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN;
+
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: process.env.NEXT_PUBLIC_ENV ?? process.env.VERCEL_ENV,
+    release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1,
+    replaysSessionSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
+    replaysOnErrorSampleRate: 1,
+    integrations: [
+      Sentry.replayIntegration({ maskAllText: false, blockAllMedia: false }),
+    ],
+  });
+}
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,24 @@
+import * as Sentry from '@sentry/nextjs';
+
+// Server + edge runtime Sentry init (App Router). No-ops without a DSN so local
+// dev and PR previews without the env var stay silent.
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+export function register(): void {
+  if (!SENTRY_DSN) {
+    return;
+  }
+
+  const options = {
+    dsn: SENTRY_DSN,
+    environment: process.env.NEXT_PUBLIC_ENV ?? process.env.VERCEL_ENV,
+    release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1,
+  };
+
+  if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
+    Sentry.init(options);
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from 'next-intl/plugin';
+import { withSentryConfig } from '@sentry/nextjs';
 
 const withNextIntl = createNextIntlPlugin('./i18n.ts');
 
@@ -87,4 +88,13 @@ const nextConfig: NextConfig = {
   generateEtags: false,
 };
 
-export default withNextIntl(nextConfig);
+export default withSentryConfig(withNextIntl(nextConfig), {
+  org: 'wp-f2',
+  project: 'landing',
+  sentryUrl: 'https://wp-f2.sentry.io/',
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  silent: !process.env.CI,
+  widenClientFileUpload: true,
+  disableLogger: true,
+  automaticVercelMonitors: false,
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@sanity/document-internationalization": "^6.0.1",
     "@sanity/image-url": "^1.1.0",
     "@sanity/vision": "^3.92.0",
+    "@sentry/nextjs": "latest",
     "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Adds Sentry to the landing — until now it had **no error monitoring** (prod issues like the i18n `MISSING_MESSAGE` were only visible via `vercel logs`). Mirrors the frontend-web setup (org `wp-f2`).

## What
- `@sentry/nextjs` dependency.
- `instrumentation.ts` — server + edge init + `onRequestError`.
- `instrumentation-client.ts` — browser init (+ Session Replay).
- `next.config.ts` wrapped with `withSentryConfig` (project `landing`).
- All **no-op without a DSN** → dev and PR previews stay silent.

## ⚙️ Manual steps before it works (only you can do)
1. Create a **`landing`** project in the `wp-f2` Sentry org → get the DSN.
2. In Vercel (landing project) set: `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN` (for sourcemap upload), optionally `NEXT_PUBLIC_SENTRY_RELEASE`.

## Notes
- Independent of the A/B PRs — separate concern, mergeable on its own.
- Couldn't build-verify locally (dep not installed in the worktree); the **Vercel preview build is the gate** — if `withSentryConfig` is off, the preview build fails before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
