### PR TITLE
fix(hero): Mapbox token fallback for search autocomplete in prod

### DIFF
--- a/src/components/HeroSearch.tsx
+++ b/src/components/HeroSearch.tsx
@@ -18,7 +18,12 @@ import { trackEvent } from '@/lib/tracking';
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://app.weplanify.com';
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.weplanify.com';
-const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN || '';
+// Public Mapbox token (pk.*, exposed client-side). Hardcoded fallback because
+// NEXT_PUBLIC_MAPBOX_TOKEN is only set in Vercel's Development env — same
+// convention as APP_URL/API_URL above.
+const MAPBOX_TOKEN =
+  process.env.NEXT_PUBLIC_MAPBOX_TOKEN ||
+  'pk.eyJ1IjoidGhlb2d1IiwiYSI6ImNtOWVxMXpzNzBxNjcycXM1eDhxMm03bmcifQ.GOt3xdrm4HGPX4ArqJGoRg';
 
 interface HeroData {
   affiliateTag?: string | null;


### PR DESCRIPTION
Search-hero destination autocomplete was dead in prod: NEXT_PUBLIC_MAPBOX_TOKEN is only set in Vercel **Development**, so the prod build inlined an empty token and the Mapbox call was skipped.

Fix: hardcode the dev token (public pk.* — exposed client-side anyway) as a fallback, same convention the repo already uses for APP_URL / API_URL / GTM_ID.

Note: GitHub push-protection flags any Mapbox JWT as a “secret” (false positive for pk.* tokens) — allowed via the unblock URL.
TODO after testing: restrict the token to weplanify.com in Mapbox settings.

NEXT_PUBLIC = baked at build, so merge + rebuild activates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)