### PR TITLE
feat(hero): drive the A/B via the eguth hero-search feature flag (Vision)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,12 @@ NEXT_PUBLIC_GTM_ID=GTM-MJHJL7Q2
 OPENAI_API_KEY=
 OPENUI_TRIP_PREVIEW_MODEL=gpt-4o-mini
 
-# Home-hero A/B experiment. Off by default: ships search dark (reach via ?hero=search).
-# Set to true to start the 50/50 split.
-HERO_AB_ENABLED=false
+# Eguth feature flags (Vision). Drives the home-hero A/B via the `hero-search`
+# flag — toggled/rolled out remotely in Vision, no redeploy. Unset = defaults
+# (control). NPM_TOKEN is needed at build time to install the private @theogu pkg.
+EGUTH_FLAGS_URL=https://vision.eguth.io/api/flags/evaluate
+EGUTH_FLAGS_API_KEY=
+NPM_TOKEN=
 
 # Sentry (error monitoring). Leave unset to disable (no-op).
 NEXT_PUBLIC_SENTRY_DSN=

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+@theogu:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
+always-auth=true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,7 @@
 nodeLinker: node-modules
+
+npmScopes:
+  theogu:
+    npmRegistryServer: "https://npm.pkg.github.com"
+    npmAlwaysAuth: true
+    npmAuthToken: "${NPM_TOKEN}"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@sanity/image-url": "^1.1.0",
     "@sanity/vision": "^3.92.0",
     "@sentry/nextjs": "latest",
+    "@theogu/eguth-feature-flags": "^0.1.0",
     "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,6 +8,7 @@ import HeroPitchWall from "@/components/HeroPitchWall";
 import HeroSearch from "@/components/HeroSearch";
 import HeroVariantSwitcher from "@/components/HeroVariantSwitcher";
 import { cookies } from "next/headers";
+import { getFlags } from "@/lib/flags";
 
 // Lazy-load below-the-fold components to reduce initial JS bundle
 const BigFeaturesSection = dynamic(() => import("@/components/BigFeaturesSection"));
@@ -38,15 +39,24 @@ export function generateStaticParams() {
 export default async function HomePage({ params, searchParams }: Props) {
   const { locale } = await params;
   const { hero: heroParam } = await searchParams;
-  // A/B hero variant. Precedence: explicit ?hero= (QA/dev override) > the cookie
-  // assigned 50/50 by middleware > "ai" (control). "search" = variant B.
-  const cookieVariant = (await cookies()).get('hero_variant')?.value;
-  const heroVariant: 'ai' | 'search' =
-    heroParam === 'search' || heroParam === 'ai'
-      ? heroParam
-      : cookieVariant === 'search'
-        ? 'search'
-        : 'ai';
+  // A/B hero variant. Precedence: explicit ?hero= (QA/dev override) > sticky
+  // override cookie > the `hero-search` feature flag (Vision, bucketed by the
+  // stable wp_vid set in middleware) > "ai" (control). "search" = variant B.
+  const cookieStore = await cookies();
+  const overrideCookie = cookieStore.get('hero_variant')?.value;
+  let heroVariant: 'ai' | 'search' = 'ai';
+  if (heroParam === 'search' || heroParam === 'ai') {
+    heroVariant = heroParam;
+  } else if (overrideCookie === 'search' || overrideCookie === 'ai') {
+    heroVariant = overrideCookie;
+  } else {
+    const visitorId = cookieStore.get('wp_vid')?.value;
+    if (visitorId) {
+      const flags = getFlags();
+      await flags.prefetch();
+      if (flags.isEnabled('hero-search', { userId: visitorId })) heroVariant = 'search';
+    }
+  }
   const isDev = process.env.NODE_ENV === 'development';
   setRequestLocale(locale);
   const t = await getTranslations("homePage");

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,23 @@
+import { EguthFlags } from '@theogu/eguth-feature-flags';
+
+// Singleton feature-flag client (Vision-controlled). Server-side only — the API
+// key must never reach the browser. The home-hero A/B is driven by the
+// `hero-search` flag (PERCENTAGE): enabled bucket = search variant, else the AI
+// control. Rollout % and on/off are flipped remotely in Vision, no redeploy.
+let flags: EguthFlags | null = null;
+
+export function getFlags(): EguthFlags {
+  if (flags) return flags;
+
+  flags = new EguthFlags({
+    app: 'weplanify',
+    endpoint: process.env.EGUTH_FLAGS_URL ?? 'https://vision.eguth.io/api/flags/evaluate',
+    apiKey: process.env.EGUTH_FLAGS_API_KEY ?? '',
+    // Keep SSR snappy: if Vision is slow/unreachable we fall back to defaults
+    // (control) rather than blocking the render.
+    timeout: 1500,
+    defaults: { 'hero-search': false },
+  });
+
+  return flags;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,38 +5,28 @@ import { routing } from './i18n/routing';
 const intlMiddleware = createMiddleware(routing);
 
 const HERO_VARIANT_COOKIE = 'hero_variant';
-const HERO_VARIANTS = ['ai', 'search'] as const;
+const VISITOR_ID_COOKIE = 'wp_vid';
 const HERO_COOKIE_OPTS = { path: '/', maxAge: 60 * 60 * 24 * 180, sameSite: 'lax' as const };
 
-// Off by default: the first deploy ships the search variant dark — everyone
-// stays on the control (AI) and only `?hero=search` reaches it. Flip to "true"
-// to start enrolling real visitors in the 50/50 experiment.
-const HERO_AB_ENABLED = process.env.HERO_AB_ENABLED === 'true';
-
 /**
- * Resolve the home-hero A/B variant for this request and persist it in a cookie.
+ * Prepare the home-hero A/B experiment for this request.
  *
- * - `?hero=ai|search` is an explicit override (QA / dark-launch testing) and is
- *   made sticky so the chosen variant survives navigation across the funnel.
- * - Otherwise, only when the experiment is enabled do we enroll the visitor in a
- *   stable 50/50 bucket. While disabled, no cookie is set → the page defaults to
- *   the control.
+ * - `?hero=ai|search` is an explicit override (QA / dark-launch) and is made
+ *   sticky via a cookie so the chosen variant survives funnel navigation.
+ * - Ensures a stable anonymous visitor id (`wp_vid`). The page resolves the
+ *   variant deterministically from this id via the `hero-search` feature flag
+ *   (Vision) — the on/off + rollout % are controlled remotely, nothing is
+ *   decided here. The `/` → `/{locale}` redirect carries the new cookie so the
+ *   landing request that renders the hero already sees it.
  */
-function assignHeroVariant(request: NextRequest, response: NextResponse): NextResponse {
+function applyHeroExperiment(request: NextRequest, response: NextResponse): NextResponse {
   const override = request.nextUrl.searchParams.get('hero');
   if (override === 'ai' || override === 'search') {
     response.cookies.set(HERO_VARIANT_COOKIE, override, HERO_COOKIE_OPTS);
-    return response;
   }
 
-  if (!HERO_AB_ENABLED) {
-    return response;
-  }
-
-  const current = request.cookies.get(HERO_VARIANT_COOKIE)?.value;
-  if (!HERO_VARIANTS.includes(current as (typeof HERO_VARIANTS)[number])) {
-    const assigned = Math.random() < 0.5 ? 'ai' : 'search';
-    response.cookies.set(HERO_VARIANT_COOKIE, assigned, HERO_COOKIE_OPTS);
+  if (!request.cookies.get(VISITOR_ID_COOKIE)?.value) {
+    response.cookies.set(VISITOR_ID_COOKIE, crypto.randomUUID(), HERO_COOKIE_OPTS);
   }
   return response;
 }
@@ -69,10 +59,10 @@ export default function middleware(request: NextRequest) {
     // Vary on Accept-Language so each locale gets a fair shot at being the
     // canonical for its language instead of one being a permanent redirect target.
     response.headers.set('Vary', 'Accept-Language');
-    return assignHeroVariant(request, response);
+    return applyHeroExperiment(request, response);
   }
 
-  return assignHeroVariant(request, intlMiddleware(request));
+  return applyHeroExperiment(request, intlMiddleware(request));
 }
 
 export const config = {


### PR DESCRIPTION
Replaces HERO_AB_ENABLED + random cookie split with the remote **hero-search** flag (Vision). Middleware sets a stable wp_vid; the page resolves the variant via the flag (PERCENTAGE, deterministic by wp_vid). On/off + rollout % are controlled in Vision, no redeploy; control fallback if Vision is unreachable.

**Draft — not buildable until:**
1. lockfile synced: yarn install (needs NPM_TOKEN) + commit yarn.lock
2. Vercel landing env: NPM_TOKEN (build) + EGUTH_FLAGS_API_KEY (runtime)
3. flag hero-search created in Vision (done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)