### PR TITLE
chore(analytics): hardcode OpenReplay project key fallback

### DIFF
--- a/src/components/OpenReplay.tsx
+++ b/src/components/OpenReplay.tsx
@@ -11,7 +11,8 @@ import { useEffect } from "react";
 //
 // Cloud setup needs only the project key; `ingestPoint` is for self-hosted.
 
-const PROJECT_KEY = process.env.NEXT_PUBLIC_OPENREPLAY_PROJECT_KEY;
+// Hardcoded fallback so replay works without setting the env var; env still wins if present.
+const PROJECT_KEY = process.env.NEXT_PUBLIC_OPENREPLAY_PROJECT_KEY ?? "FYlS2xW7GGUyPQYqzRpP";
 const INGEST_POINT = process.env.NEXT_PUBLIC_OPENREPLAY_INGEST_POINT; // optional, self-hosted only
 
 // Must match CookieConsent.tsx.


### PR DESCRIPTION
Forces the OpenReplay cloud project key as a fallback so session replay works without setting `NEXT_PUBLIC_OPENREPLAY_PROJECT_KEY` on Vercel. The env var still takes precedence if present.

Consent gating is unchanged — replay still only starts after cookie consent.

Note: `NEXT_PUBLIC_*` keys are exposed client-side either way, so this only moves the key into the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)