### PR TITLE
feat(flags): emit feature_flag.exposure for hero A/B (Vision results)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@sanity/image-url": "^1.1.0",
     "@sanity/vision": "^3.92.0",
     "@sentry/nextjs": "latest",
-    "@theogu/eguth-feature-flags": "^0.1.0",
+    "@theogu/eguth-feature-flags": "^0.2.0",
     "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,10 +1,55 @@
 import { EguthFlags } from '@theogu/eguth-feature-flags';
+import { after } from 'next/server';
 
 // Singleton feature-flag client (Vision-controlled). Server-side only — the API
 // key must never reach the browser. The home-hero A/B is driven by the
 // `hero-search` flag (PERCENTAGE): enabled bucket = search variant, else the AI
 // control. Rollout % and on/off are flipped remotely in Vision, no redeploy.
 let flags: EguthFlags | null = null;
+
+// Feature-flag exposures are plain tracking events ingested into Vision, where
+// the flag analytics aggregate them into per-variant exposure + conversion
+// breakdowns. The tracker key is bound to the same Vision app as the flags key,
+// so exposures land where the analytics read them.
+const EXPOSURE_INGEST_URL =
+  process.env.EGUTH_TRACKER_URL ?? 'https://vision.eguth.io/api/events/ingest';
+const EXPOSURE_API_KEY = process.env.EGUTH_TRACKER_API_KEY ?? '';
+
+/**
+ * Record a feature-flag exposure in Vision (which user saw which variant).
+ * Scheduled with `after()` so the serverless function stays alive until the
+ * POST completes — otherwise Vercel may freeze the function once the response
+ * is sent and silently drop the request. Fully best-effort: any failure is
+ * swallowed so analytics can never break a render.
+ */
+function recordExposure(flagKey: string, variant: string, userId?: string): void {
+  // Vision attributes exposures by userId; skip anonymous evaluations.
+  if (!EXPOSURE_API_KEY || !userId) return;
+
+  try {
+    after(async () => {
+      try {
+        await fetch(EXPOSURE_INGEST_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-API-Key': EXPOSURE_API_KEY },
+          body: JSON.stringify({
+            events: [
+              {
+                name: 'feature_flag.exposure',
+                userId,
+                properties: { flag: flagKey, variant },
+              },
+            ],
+          }),
+        });
+      } catch {
+        // Best-effort analytics — never surface ingest failures.
+      }
+    });
+  } catch {
+    // `after` is only available inside a request scope; ignore otherwise.
+  }
+}
 
 export function getFlags(): EguthFlags {
   if (flags) return flags;
@@ -17,6 +62,10 @@ export function getFlags(): EguthFlags {
     // (control) rather than blocking the render.
     timeout: 1500,
     defaults: { 'hero-search': false },
+    // Record which users enter which variant so Vision can build per-variant
+    // analytics. The SDK de-dupes per (flag, user, variant), so this fires at
+    // most once per visitor per variant.
+    onExposure: (e) => recordExposure(e.flagKey, e.variant, e.userId),
   });
 
   return flags;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5825,6 +5825,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@theogu/eguth-feature-flags@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@theogu/eguth-feature-flags@npm:0.2.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40theogu%2Feguth-feature-flags%2F0.2.0%2F5cfb9a68ee35de31f85db3c6f2f3e165a5d3a0f1"
+  checksum: 10c0/41c9afb76b97d2fac9040c9e65314061d6df0efcea284f96b87aeb3d0150e8d6634c185997e016de48abf285d963d83e2a3b28711b25e98c2322d35986c70aa6
+  languageName: node
+  linkType: hard
+
 "@tybys/wasm-util@npm:^0.10.0":
   version: 0.10.1
   resolution: "@tybys/wasm-util@npm:0.10.1"
@@ -16229,6 +16236,7 @@ __metadata:
     "@sanity/vision": "npm:^3.92.0"
     "@sentry/nextjs": "npm:latest"
     "@squoosh/cli": "npm:^0.7.3"
+    "@theogu/eguth-feature-flags": "npm:^0.2.0"
     "@types/node": "npm:^20"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"


### PR DESCRIPTION
## Quoi

Câble le callback `onExposure` du SDK `@theogu/eguth-feature-flags` vers l'ingestion d'events Vision, pour enregistrer **quel visiteur entre dans quelle variante** du hero A/B (`hero-search`). C'est la moitié *exposition* qui manque pour que l'onglet Résultats de Vision se remplisse (aujourd'hui : « No exposure data yet »).

## Comment

- `onExposure` → `POST /api/events/ingest` un event `feature_flag.exposure` avec `properties: { flag, variant }` et `userId = wp_vid`, via `EGUTH_TRACKER_URL` / `EGUTH_TRACKER_API_KEY`.
  - La clé tracker partage le préfixe (`eak_46b…`) avec la clé flags → même app Vision (`cmqs8b5zh…`) que `hero-search`, donc les expositions atterrissent là où l'analytics les lit.
- Programmé via `after()` (next/server) pour que la fonction serverless ne soit pas gelée avant que le POST parte. Best-effort total : ne bloque jamais le SSR, n'émet rien pour un visiteur anonyme (pas de `userId`).
- Le SDK dédupe par `(flag, user, variant)` → au plus une exposition par visiteur et par variante.

## ⚠️ Bloqué sur (prérequis avant merge)

1. **Republier `@theogu/eguth-feature-flags` avec le hook `onExposure`** — ajouté côté SDK dans le commit `2a74659` (« add result v0 »), mais **la version n'a pas été bumpée** (toujours `0.1.0`, déjà publiée sans le hook). Il faut bump (ex. `0.2.0`) + publish.
2. **Bumper cette dépendance** dans la landing vers la nouvelle version.

Tant que (1)+(2) ne sont pas faits, la CI sera **rouge** (type error : `onExposure` absent de `FlagsConfig@0.1.0`). C'est attendu — draft jusque-là.

## Étape d'après (hors scope, pour la conversion)

L'exposition seule remplit le breakdown par variante. Pour la **conversion par variante**, il faudra que l'event de conversion (`user.signup`) porte le **même `userId` (`wp_vid`)** — aujourd'hui les signups prod ont `userId: null` — et soit sur la **même app** que le flag (ou flag global).

🤖 Generated with [Claude Code](https://claude.com/claude-code)