### PR TITLE
feat(landing): emit hero A/B exposure to Vision

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,15 @@ EGUTH_FLAGS_URL=https://vision.eguth.io/api/flags/evaluate
 EGUTH_FLAGS_API_KEY=
 NPM_TOKEN=
 
+# Eguth Vision event ingest. Records the home-hero A/B exposure
+# (`experiment.exposed`, keyed by the wp_vid visitor id) so the experiments
+# dashboard can compute conversion per variant. The tracker key is the same
+# `weplanify-landing` Vision app key used for flag evaluation, so if
+# EGUTH_TRACKER_API_KEY is unset we fall back to EGUTH_FLAGS_API_KEY. Unset =
+# no events emitted (no-op).
+EGUTH_TRACKER_URL=https://vision.eguth.io/api/events/ingest
+EGUTH_TRACKER_API_KEY=
+
 # Sentry (error monitoring). Leave unset to disable (no-op).
 NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_AUTH_TOKEN=

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -9,6 +9,7 @@ import HeroSearch from "@/components/HeroSearch";
 import HeroVariantSwitcher from "@/components/HeroVariantSwitcher";
 import { cookies } from "next/headers";
 import { getFlags } from "@/lib/flags";
+import { trackExposure } from "@/lib/vision-track";
 
 // Lazy-load below-the-fold components to reduce initial JS bundle
 const BigFeaturesSection = dynamic(() => import("@/components/BigFeaturesSection"));
@@ -55,6 +56,9 @@ export default async function HomePage({ params, searchParams }: Props) {
       const flags = getFlags();
       await flags.prefetch();
       if (flags.isEnabled('hero-search', { userId: visitorId })) heroVariant = 'search';
+      // Real bucketed visitor (not a QA/dev override) — record the exposure to
+      // Vision so the experiments dashboard can compute conversion per variant.
+      trackExposure(visitorId, heroVariant);
     }
   }
   const isDev = process.env.NODE_ENV === 'development';

--- a/src/lib/vision-track.ts
+++ b/src/lib/vision-track.ts
@@ -1,0 +1,49 @@
+import { after } from 'next/server';
+
+// A/B experiment instrumentation → eguth Vision. Mirrors the backend's
+// EguthTrackerService contract: POST /api/events/ingest, `X-API-Key` auth, body
+// `{ events: [{ name, properties, userId, timestamp }] }`. The landing's Vision
+// key is scoped to the `weplanify-landing` app and is already provisioned for
+// flag evaluation, so we reuse it for ingest unless an explicit tracker key is
+// set. Server-only: the API key must never reach the browser.
+const INGEST_URL =
+  process.env.EGUTH_TRACKER_URL ?? 'https://vision.eguth.io/api/events/ingest';
+const API_KEY =
+  process.env.EGUTH_TRACKER_API_KEY ?? process.env.EGUTH_FLAGS_API_KEY ?? '';
+
+const EXPERIMENT = 'home_hero';
+const FLAG = 'hero-search';
+
+/**
+ * Record an A/B exposure for the home-hero experiment, keyed by the stable
+ * `wp_vid` visitor id so the Vision experiments dashboard can compute
+ * conversion per variant (dedup at query time on distinct userId).
+ *
+ * Fire-and-forget: the POST is scheduled with `after()` so it runs after the
+ * response and never blocks SSR, and the call silently no-ops when Vision is
+ * unconfigured (e.g. local dev without a key) or the visitor id is missing.
+ */
+export function trackExposure(visitorId: string, variant: 'ai' | 'search'): void {
+  if (!API_KEY || !visitorId) return;
+
+  after(async () => {
+    try {
+      await fetch(INGEST_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-API-Key': API_KEY },
+        body: JSON.stringify({
+          events: [
+            {
+              name: 'experiment.exposed',
+              userId: visitorId,
+              properties: { experiment: EXPERIMENT, flag: FLAG, variant },
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        }),
+      });
+    } catch {
+      // Analytics must never break the page — swallow errors.
+    }
+  });
+}


### PR DESCRIPTION
## Problem

The home-hero A/B (`hero-search` flag) is live and splitting traffic (flag eval key for the `weplanify-landing` Vision app was used today), and the assigned variant is pushed to the GTM dataLayer (`hero_variant` / `experiment_view`). **But nothing is sent to eguth Vision** — the `weplanify-landing` app has **0 events**, so the experiments dashboard has no exposure data and cannot compute conversion per variant.

## Change

- New server-side helper `src/lib/vision-track.ts` → `trackExposure(visitorId, variant)`:
  - Emits an `experiment.exposed` event (`properties: { experiment: "home_hero", flag: "hero-search", variant }`), keyed by the stable `wp_vid` visitor id.
  - Mirrors the backend `EguthTrackerService` ingest contract (`POST /api/events/ingest`, `X-API-Key`, `{ events: [{ name, properties, userId, timestamp }] }`).
  - Fired via Next 15 `after()` so it runs after the response and never blocks SSR; fire-and-forget, swallows errors.
  - No-ops when no key is configured (e.g. local dev).
- Wired into `src/app/[locale]/page.tsx`: emitted **only for real bucketed visitors** (the flag-decision branch), not `?hero=` / sticky QA overrides.
- `.env.example`: documents `EGUTH_TRACKER_URL` / `EGUTH_TRACKER_API_KEY`.

## Deploy note (no new secret needed)

The tracker reuses the existing `weplanify-landing` Vision key already provisioned for flag evaluation: if `EGUTH_TRACKER_API_KEY` is unset it falls back to `EGUTH_FLAGS_API_KEY`. So once merged + deployed, exposures should flow with no env change. Optionally set `EGUTH_TRACKER_API_KEY` explicitly to decouple the two.

## Follow-up (out of scope)

Conversion linking: signups are tracked by the backend under the `weplanify` app keyed by the app user UUID, not `wp_vid`. To compute exposure→signup the `wp_vid`/variant must be threaded through signup. This PR delivers the exposure leg; the dashboard can already count exposures per variant (dedup at query time on distinct `userId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)