### PR TITLE
feat(landing): record hero A/B signup-CTA conversion to Vision

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { Analytics } from "@/components/Analytics";
 import { PageViewTracker } from "@/lib/analytics/page-view-tracker";
 import { FirstTouchTracker } from "@/lib/attribution/first-touch-tracker";
 import { FirstTouchLinkRewriter } from "@/lib/attribution/first-touch-link-rewriter";
+import { SignupConversionBeacon } from "@/lib/attribution/signup-conversion-beacon";
 import CookieConsent from "@/components/CookieConsent";
 import OpenReplay from "@/components/OpenReplay";
 import StickyCTA from "@/components/StickyCTA";
@@ -110,6 +111,8 @@ export default async function LocaleLayout({ children, params }: Props) {
           <FirstTouchTracker />
           {/* Rewrites in-content register CTAs to the first-touch source at click time */}
           <FirstTouchLinkRewriter />
+          {/* Records the home-hero A/B conversion when a register CTA is clicked */}
+          <SignupConversionBeacon />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/app/api/track-conversion/route.ts
+++ b/src/app/api/track-conversion/route.ts
@@ -1,0 +1,53 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+// Landing-side conversion event for the home-hero A/B. The signup CTAs point to
+// app.weplanify.com (a different origin), so we can't observe the actual
+// account creation from here — but the click is the primary conversion the hero
+// is meant to drive. We record it under the same Vision app + visitor id
+// (`wp_vid`) as the `feature_flag.exposure` events, so the flag analytics can
+// join exposure -> conversion per variant purely on userId.
+//
+// The visitor id never reaches the browser: the client beacons this same-origin
+// route (cookies attached) and we read `wp_vid` server-side, mirroring the
+// flags.ts ingest contract. The tracker key is the weplanify-landing Vision app
+// key, reused from flag evaluation when no explicit tracker key is set.
+const INGEST_URL =
+  process.env.EGUTH_TRACKER_URL ?? 'https://vision.eguth.io/api/events/ingest';
+const API_KEY =
+  process.env.EGUTH_TRACKER_API_KEY ?? process.env.EGUTH_FLAGS_API_KEY ?? '';
+
+const CONVERSION_EVENT = 'landing.signup_cta_click';
+
+export async function POST() {
+  if (!API_KEY) return new NextResponse(null, { status: 204 });
+
+  const cookieStore = await cookies();
+  const visitorId = cookieStore.get('wp_vid')?.value;
+  if (!visitorId) return new NextResponse(null, { status: 204 });
+
+  // Carry the assigned variant when known — not required for the userId-based
+  // join, but handy for debugging in the raw event stream.
+  const variant = cookieStore.get('hero_variant')?.value;
+
+  try {
+    await fetch(INGEST_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': API_KEY },
+      body: JSON.stringify({
+        events: [
+          {
+            name: CONVERSION_EVENT,
+            userId: visitorId,
+            properties: { experiment: 'home_hero', ...(variant ? { variant } : {}) },
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      }),
+    });
+  } catch {
+    // Best-effort analytics — never surface ingest failures to the client.
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/lib/attribution/signup-conversion-beacon.tsx
+++ b/src/lib/attribution/signup-conversion-beacon.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Records a home-hero A/B conversion when the visitor clicks through to signup.
+ *
+ * Register CTAs point to `app.weplanify.com/...register` (a different origin),
+ * so the click is a plain `<a>` navigation that leaves the landing — the click
+ * itself is the conversion we can observe here. We beacon a same-origin route
+ * that reads the `wp_vid` cookie server-side and emits the conversion event to
+ * Vision, so the visitor id never touches client JS and survives the page
+ * leaving via `sendBeacon` (queued by the browser even mid-navigation).
+ *
+ * Hooks `pointerdown` (capture) so it fires once per click and also catches
+ * middle-click / modifier-click opens. Fires at most once per page load —
+ * Vision attributes conversion per distinct user, so one event is enough.
+ */
+export function SignupConversionBeacon() {
+	useEffect(() => {
+		let fired = false;
+
+		const onPointerDown = (event: Event) => {
+			if (fired) return;
+			const target = event.target;
+			if (!(target instanceof Element)) return;
+
+			const anchor = target.closest<HTMLAnchorElement>('a[href*="app.weplanify.com"]');
+			if (!anchor) return;
+
+			let url: URL;
+			try {
+				url = new URL(anchor.href);
+			} catch {
+				return;
+			}
+			if (url.hostname !== "app.weplanify.com" || !url.pathname.endsWith("/register")) return;
+
+			fired = true;
+			navigator.sendBeacon?.("/api/track-conversion");
+		};
+
+		document.addEventListener("pointerdown", onPointerDown, true);
+		return () => document.removeEventListener("pointerdown", onPointerDown, true);
+	}, []);
+
+	return null;
+}


### PR DESCRIPTION
## Context

[#107](https://github.com/eguth-io/weplanify-landing/pull/107) shipped hero A/B **exposures** (`feature_flag.exposure`, keyed by `wp_vid`, under the `weplanify-landing` Vision app). This adds the **conversion** leg so the flag's results tab shows a per-variant conversion rate.

## How Vision joins (from `eguth-vision` `flag-analytics.service.ts`)

Conversion is computed by joining exposures to a chosen conversion event **purely on `userId`**, both filtered to the flag's app:

```sql
exposures(userId, variant)  LEFT JOIN  converters(userId)  ON userId = userId
```

So the conversion event must (a) live under the **same app** (`weplanify-landing`) and (b) carry **`userId = wp_vid`**. The backend `user.signup` event fails both (app `weplanify`, `userId = account_id`), which is why we emit a landing-side conversion instead.

## Change

- `src/app/api/track-conversion/route.ts` — same-origin POST route. Reads the `wp_vid` cookie **server-side** and emits `landing.signup_cta_click` to Vision (`userId = wp_vid`, props `{ experiment, variant }`), mirroring the `flags.ts` ingest contract. Reuses the `weplanify-landing` key (`EGUTH_TRACKER_API_KEY` → `EGUTH_FLAGS_API_KEY` fallback). No-ops without a key / `wp_vid`.
- `src/lib/attribution/signup-conversion-beacon.tsx` — document-level `pointerdown` (capture) listener; when a `app.weplanify.com/...register` link is clicked it `navigator.sendBeacon()`s the route once per page. `wp_vid` never touches client JS; `sendBeacon` survives the cross-origin navigation.
- Mounted in `[locale]/layout.tsx` beside `FirstTouchLinkRewriter` (same register-link chokepoint).

## Why CTA-click (not account creation)

The register CTA leaves the landing for `app.weplanify.com`, so completed signup isn't observable here. The click-through is the primary action the hero is meant to drive, and is the standard primary metric for a hero A/B. Real account-creation conversion (threading `wp_vid` landing→app→backend + DB migration) is a larger cross-repo follow-up.

## After merge

In Vision, set the `hero-search` flag's **conversion event** to `landing.signup_cta_click` to read the per-variant rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)